### PR TITLE
Fix db script 'Missing references in protonym authorships'

### DIFF
--- a/lib/database_scripts/renderers/markdown.rb
+++ b/lib/database_scripts/renderers/markdown.rb
@@ -4,6 +4,7 @@ module DatabaseScripts::Renderers::Markdown
   end
 
   def markdown_taxon_link taxon
+    return "" unless taxon
     "%taxon#{taxon.id}"
   end
 

--- a/lib/database_scripts/scripts/missing_references_in_protonym_authorships.rb
+++ b/lib/database_scripts/scripts/missing_references_in_protonym_authorships.rb
@@ -17,7 +17,7 @@ class DatabaseScripts::Scripts::MissingReferencesInProtonymAuthorships
 
         [ protonym.name.protonym_with_fossil_html(protonym.fossil),
           markdown_taxon_link(taxon),
-          taxon.status,
+          taxon.try(:status),
           citation_search_link(reference.citation),
           reference_link(reference) ]
       end


### PR DESCRIPTION
http://antcat.org/database_scripts/missing_references_in_protonym_authorships does not render because `Protonym.find(164534)`'s `has_one :taxon` has been deleted.