### PR TITLE
Link reference sections

### DIFF
--- a/app/assets/stylesheets/controllers/_catalog.sass
+++ b/app/assets/stylesheets/controllers/_catalog.sass
@@ -112,6 +112,8 @@
           padding-top: 6px
         .title_taxt + .subtitle_taxt
           padding-top: 0
+      .section:hover .show-on-hover
+        display: inline
 
     .change_history
       font-size: 13px

--- a/app/decorators/taxon_decorator.rb
+++ b/app/decorators/taxon_decorator.rb
@@ -43,16 +43,6 @@ class TaxonDecorator < ApplicationDecorator
       class: 'genus_species_header_notes_taxt'
   end
 
-  def references
-    return unless taxon.reference_sections.present?
-
-    helpers.content_tag :div, class: 'reference_sections' do
-      taxon.reference_sections.reduce(''.html_safe) do |content, section|
-        content << reference_section(section)
-      end
-    end
-  end
-
   def taxon_status
     # Note: Cleverness is used here to make these queries (e.g.: obsolete_combination?)
     # appear as tags. That's how CSS does its coloring.
@@ -88,17 +78,6 @@ class TaxonDecorator < ApplicationDecorator
   end
 
   private
-    def reference_section section
-      helpers.content_tag :div, class: 'section' do
-        [:title_taxt, :subtitle_taxt, :references_taxt].reduce(''.html_safe) do |content, field|
-          if section[field].present?
-            content << helpers.content_tag(:div, TaxtPresenter[section[field]].to_html, class: field)
-          end
-          content
-        end
-      end
-    end
-
     def format_senior_synonym
       current_valid_taxon = taxon.current_valid_taxon_including_synonyms
       return '' unless current_valid_taxon

--- a/app/views/catalog/_reference_sections.haml
+++ b/app/views/catalog/_reference_sections.haml
@@ -1,0 +1,8 @@
+-if taxon.reference_sections.present?
+  .reference_sections
+    -taxon.reference_sections.each do |section|
+      .section
+        -[:title_taxt, :subtitle_taxt, :references_taxt].each do |field|
+          -if section[field].present?
+            %div{class: field}
+              =TaxtPresenter[section[field]].to_html

--- a/app/views/catalog/_reference_sections.haml
+++ b/app/views/catalog/_reference_sections.haml
@@ -6,3 +6,5 @@
           -if section[field].present?
             %div{class: field}
               =TaxtPresenter[section[field]].to_html
+        -if current_user
+          %small.show-on-hover=link_to "History", reference_section_path(section), class: "btn-normal btn-tiny"

--- a/app/views/catalog/_taxon_description.haml
+++ b/app/views/catalog/_taxon_description.haml
@@ -26,5 +26,5 @@
   %br
   =link_to "Formicidae family references", catalog_path(429011)
 -else
-  =taxon.decorate.references
+  =render "reference_sections", taxon: taxon
   =taxon_change_history taxon

--- a/app/views/catalog/_taxon_description.haml
+++ b/app/views/catalog/_taxon_description.haml
@@ -17,7 +17,7 @@
       %li
         =add_period_if_necessary TaxtPresenter[history_item.taxt].to_html
         -if current_user
-          %small.show-on-hover=link_to "##{history_item.id}", taxon_history_item_path(history_item), class: "gray"
+          %small.show-on-hover=link_to "History", taxon_history_item_path(history_item), class: "btn-normal btn-tiny"
 
 =taxon.decorate.child_lists
 

--- a/lib/exporters/antweb/export_reference_sections.rb
+++ b/lib/exporters/antweb/export_reference_sections.rb
@@ -1,0 +1,29 @@
+class Exporters::Antweb::ExportReferenceSections
+  include ActionView::Helpers::TagHelper
+
+  def initialize taxon
+    @taxon = taxon
+  end
+
+  def reference_sections
+    return unless @taxon.reference_sections.present?
+
+    content_tag :div, class: 'reference_sections' do
+      @taxon.reference_sections.reduce(''.html_safe) do |content, section|
+        content << reference_section(section)
+      end
+    end
+  end
+
+  private
+    def reference_section section
+      content_tag :div, class: 'section' do
+        [:title_taxt, :subtitle_taxt, :references_taxt].reduce(''.html_safe) do |content, field|
+          if section[field].present?
+            content << content_tag(:div, TaxtPresenter[section[field]].to_html, class: field)
+          end
+          content
+        end
+      end
+    end
+end

--- a/lib/exporters/antweb/exporter.rb
+++ b/lib/exporters/antweb/exporter.rb
@@ -1,4 +1,6 @@
 # Export via `rake antweb:export`.
+# This class will grow for some more time while decoupling the export
+# code from the rest of the code.
 
 include ActionView::Helpers::TagHelper # For `#content_tag`.
 include ActionView::Context # For `#content_tag`.
@@ -214,7 +216,7 @@ class Exporters::Antweb::Exporter
           content << taxon.headline
           content << export_history_items(taxon)
           content << taxon.child_lists
-          content << taxon.references
+          content << export_reference_sections(taxon)
         end
       ensure
         $use_ant_web_formatter = false
@@ -223,6 +225,10 @@ class Exporters::Antweb::Exporter
 
     def export_history_items taxon
       Exporters::Antweb::ExportHistoryItems.new(taxon).history
+    end
+
+    def export_reference_sections taxon
+      Exporters::Antweb::ExportReferenceSections.new(taxon).reference_sections
     end
 
     def self.antcat_taxon_link taxon, label = "AntCat"


### PR DESCRIPTION
- Link reference sections (to make their revision histories browsable)
- Extract/split AntWeb export-related code to make the above change possible
- Slightly change the format/style of the links to the revision histories

CI is green: https://travis-ci.org/jonkerz/antcat/builds/240161312?utm_source=github_status&utm_medium=notification