### PR TITLE
feat: Tweak to avoid "(synonyms)" without context

### DIFF
--- a/app/decorators/taxon_decorator/statistics.rb
+++ b/app/decorators/taxon_decorator/statistics.rb
@@ -2,7 +2,7 @@ class TaxonDecorator::Statistics
   include ActionView::Helpers
   include ActionView::Context
   include Service
-  include ApplicationHelper # For #pluralize_with_delimiters and #count_and_status.
+  include ApplicationHelper # For `#pluralize_with_delimiters` and `#number_with_delimiter`.
 
   # TODO: Push include_invalid/include_fossil to the taxa models.
   # This method is cheap, but Taxon#statistics is very slow and it always
@@ -53,11 +53,15 @@ class TaxonDecorator::Statistics
       statistics = statistics[rank]
       return unless statistics
 
-      strings = []
-      strings << valid_statistics(statistics, rank, include_invalid)
-      strings << invalid_statistics(statistics) if include_invalid
+      valid_string = valid_statistics statistics, rank, include_invalid
+      return valid_string unless include_invalid
 
-      strings.compact.join ' '
+      invalid_string = invalid_statistics statistics
+      if invalid_string && valid_string.blank?
+        valid_string = "0 valid #{rank}"
+      end
+
+      [valid_string, invalid_string].compact.join ' '
     end
 
     def valid_statistics statistics, rank, include_invalid

--- a/spec/decorators/taxon_decorator/statistics_spec.rb
+++ b/spec/decorators/taxon_decorator/statistics_spec.rb
@@ -108,14 +108,15 @@ describe TaxonDecorator::Statistics do
       expect(described_class[statistics]).to eq '<p>1 valid subspecies</p>'
     end
 
-    it "handles when there are no valid rank members" do
-      species = create :species
-      create :subspecies, species: species, status: 'synonym'
-
-      statistics = {
-        extant: { subspecies: { 'synonym' => 1 } }
-      }
-      expect(described_class[statistics]).to eq '<p>(1 synonym)</p>'
+    context "when there is no valid rank statistics" do
+      context "when there is invalid rank statistics" do
+        it "appends '0 valid' before the invalid rank statistics" do
+          statistics = {
+            extant: { subspecies: { 'synonym' => 1 } }
+          }
+          expect(described_class[statistics]).to eq '<p>0 valid subspecies (1 synonym)</p>'
+        end
+      end
     end
 
     it "doesn't pluralize certain statuses" do


### PR DESCRIPTION
Related to #275.

![0valid](https://user-images.githubusercontent.com/1513381/30609506-e1806694-9d7b-11e7-93fa-4f0b7f39a8f2.png)
