### PR TITLE
fix: Attempt to fix DOI search in Solr

### DIFF
--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -57,6 +57,7 @@ class Reference < ApplicationRecord
     integer :year
     text    :author_names_string
     text    :citation_year
+    text    :doi, as: :doi
     text    :title
     text    :journal_name do journal.name if journal end
     text    :publisher_name do publisher.name if publisher end
@@ -67,9 +68,6 @@ class Reference < ApplicationRecord
     text    :taxonomic_notes
     string  :citation_year
     string  :author_names_string
-    # Tried adding DOI here, we get "NoMethodError: undefined method `doi' for #<MissingReference ...>"
-    # Missing references shouldn't have a DOI, I would think.
-    # TODO: Test searching for doi, see if that works?
   end
 
   def self.requires_title

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -78,6 +78,26 @@
         <filter class="solr.PorterStemFilterFactory"/>
       </analyzer>
     </fieldType>
+    <!-- *** Added for AntCat *** -->
+    <!-- I'm not sure which field to use for this, but the original
+         issue is: given a reference with the doi "10.1111/syen.12253",
+         searching for "10.1111" yields no results without something like this.
+     -->
+    <fieldType name="doi" class="solr.TextField" omitNorms="false">
+      <analyzer type="index">
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.StandardFilterFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.PorterStemFilterFactory"/>
+        <filter class="solr.EdgeNGramFilterFactory" minGramSize="1" maxGramSize="45" side="front"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.StandardFilterFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.PorterStemFilterFactory"/>
+      </analyzer>
+    </fieldType>
     <!-- *** This fieldType is used by Sunspot! *** -->
     <fieldType name="boolean" class="solr.BoolField" omitNorms="true"/>
     <!-- *** This fieldType is used by Sunspot! *** -->
@@ -140,6 +160,8 @@
      default: a value that should be used if no value is specified
        when adding a document.
    -->
+    <!-- *** Added for AntCat *** -->
+    <field name="doi" type="doi" indexed="true" stored="true" />
     <!-- *** This field is used by Sunspot! *** -->
     <field name="id" stored="true" type="string" multiValued="false" indexed="true"/>
     <!-- *** This field is used by Sunspot! *** -->


### PR DESCRIPTION
Issue: #90 

I'm not sure which field to use for this, but the original issue is: given a reference with the doi "10.1111/syen.12253", searching for "10.1111" yields no results without something like this.

Note: I've no idea what I'm doing.