### PR TITLE
feat: Remove 'blurb' from site notices

### DIFF
--- a/app/controllers/site_notices_controller.rb
+++ b/app/controllers/site_notices_controller.rb
@@ -69,7 +69,7 @@ class SiteNoticesController < ApplicationController
     end
 
     def site_notice_params
-      params.require(:site_notice).permit :blurb, :title, :message
+      params.require(:site_notice).permit :title, :message
     end
 
     def mark_as_read

--- a/app/views/site_notices/_form.haml
+++ b/app/views/site_notices/_form.haml
@@ -11,11 +11,6 @@
           =f.text_field :title, { maxlength: 70 }
 
       .row
-        .medium-8.columns.end
-          =f.label :blurb
-          =f.text_field :blurb, { maxlength: 255, placeholder: "Optional short description used in the 'Unread site notices' box." }
-
-      .row
         .medium-12.columns
           =f.text_area :message, rows: 10,
             data: { has_mentionables: true, has_linkables: true, previewable: true, previewable_title: "Message" }

--- a/app/views/site_notices/_unread_site_notices_flash_message.haml
+++ b/app/views/site_notices/_unread_site_notices_flash_message.haml
@@ -18,9 +18,6 @@
             ago
             %br
             =link_comments_section site_notice
-          %br
-          -if site_notice.blurb.present?
-            %p=site_notice.blurb
           %hr
         %button.close-button{"aria-label" => "Dismiss alert", "data-close" => "", type: "button"}
           %span{"aria-hidden" => "true"} &times;

--- a/app/views/site_notices/index.haml
+++ b/app/views/site_notices/index.haml
@@ -14,7 +14,6 @@
     %thead
       %tr
         %th Title
-        %th Short description
         %th Read?
         %th Comments
         %th When
@@ -22,7 +21,6 @@
     -@site_notices.each do |site_notice|
       %tr
         %td.no-wrap=link_to site_notice.title, site_notice_path(site_notice)
-        %td=site_notice.blurb.presence || "(none)"
         %td.no-wrap
           -read_status = site_notice.unread?(current_user) ? "unread" : "read"
           =antcat_icon read_status

--- a/app/views/site_notices/show.haml
+++ b/app/views/site_notices/show.haml
@@ -14,12 +14,6 @@
       =link_to "Delete", site_notice_path(@site_notice), method: :delete, data: { confirm: "Delete? This removes the site notice from the archive." }, class: "btn-delete"
 .clear
 
--if @site_notice.blurb.present?
-  .row
-    .medium-12.columns
-      .callout
-        %p=@site_notice.blurb
-
 .row
   .medium-12.columns
     .callout

--- a/db/migrate/20171001164413_remove_blurb_from_site_notices.rb
+++ b/db/migrate/20171001164413_remove_blurb_from_site_notices.rb
@@ -1,0 +1,5 @@
+class RemoveBlurbFromSiteNotices < ActiveRecord::Migration
+  def change
+    remove_column :site_notices, :blurb, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170920204730) do
+ActiveRecord::Schema.define(version: 20171001164413) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -335,7 +335,6 @@ ActiveRecord::Schema.define(version: 20170920204730) do
     t.integer  "user_id",    limit: 4
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
-    t.string   "blurb",      limit: 255
   end
 
   add_index "site_notices", ["user_id"], name: "index_site_notices_on_user_id", using: :btree

--- a/features/editors_panel/site_notices.feature
+++ b/features/editors_panel/site_notices.feature
@@ -9,7 +9,6 @@ Feature: Site notices
     When I go to the site notices page
     And I follow "New"
     And I fill in "site_notice_title" with "New AntCat features"
-    And I fill in "site_notice_blurb" with "Many!"
     And I fill in "site_notice_message" with "You would not believe it!"
     And I press "Publish"
     Then I should see "Successfully created site notice"


### PR DESCRIPTION
Simpler, we don't really need it.