### PR TITLE
fix: Missing PDF file param

### DIFF
--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -137,7 +137,7 @@ class ReferencesController < ApplicationController
         :nesting_reference_id,
         :citation,
         :author_names_string,
-        { document_attributes: [:id, :url, :public] }
+        { document_attributes: [:id, :file, :url, :public] }
       )
     end
 


### PR DESCRIPTION
Closes #352.

Broke in a32b31ef34890d411ec98f723d6d27a62f8ff9c6.