### PR TITLE
Change attribution

### DIFF
--- a/app/controllers/editors_panels/versions_controller.rb
+++ b/app/controllers/editors_panels/versions_controller.rb
@@ -19,6 +19,9 @@ module EditorsPanels
       event: {
         tag: :select_tag,
         options: -> { PaperTrail::Version.uniq.pluck(:event) }
+      },
+      change_id: {
+        tag: :number_field_tag
       }
     )
 

--- a/app/decorators/change_decorator.rb
+++ b/app/decorators/change_decorator.rb
@@ -2,6 +2,7 @@ class ChangeDecorator < Draper::Decorator
   delegate_all
 
   # Accepts optional `user` for performance reasons.
+  # TODO: Do not accept optional `user`.
   def format_adder_name user = nil
     user_verb = case change.change_type
                 when "create" then "added"

--- a/app/models/change.rb
+++ b/app/models/change.rb
@@ -4,6 +4,7 @@ class Change < ActiveRecord::Base
   belongs_to :approver, class_name: 'User'
   # TODO rename to `taxon_id`.
   belongs_to :taxon, class_name: 'Taxon', foreign_key: 'user_changed_taxon_id'
+  belongs_to :user # TODO: Validate presence of `:on_create`.
 
   has_many :versions, class_name: 'PaperTrail::Version'
 
@@ -103,22 +104,14 @@ class Change < ActiveRecord::Base
     version.reify
   end
 
-  # TODO probably move `changed_by` to a field in this model.
-  # Returns the user of the person who made the change. Expensive method.
   def changed_by
-    whodunnit_via_change_id || whodunnit_via_user_changed_taxon_id
+    user || whodunnit_via_change_id
   end
 
   private
+    # Backwards compatibility for changes created before `changes.user_id` was added.
     def whodunnit_via_change_id
       version = versions.where.not(whodunnit: nil).first
-      version.try :user
-    end
-
-    # Backwards compatibility, possibly covers other cases too.
-    def whodunnit_via_user_changed_taxon_id
-      version = PaperTrail::Version.where(item_id: user_changed_taxon_id)
-        .where.not(whodunnit: nil).last
       version.try :user
     end
 

--- a/app/views/changes/_change.haml
+++ b/app/views/changes/_change.haml
@@ -11,7 +11,7 @@
       =format_taxon_name taxon.name
   %td=link_to change.format_created_at, change
   -# TODO: N+1 query.
-  %td=change.versions.count
+  %td=link_to change.versions.count, versions_path(change_id: change.id)
   %td
     -if change.approver
       =change.format_approver_name

--- a/app/views/changes/_change.haml
+++ b/app/views/changes/_change.haml
@@ -10,6 +10,8 @@
     -else
       =format_taxon_name taxon.name
   %td=link_to change.format_created_at, change
+  -# TODO: N+1 query.
+  %td=change.versions.count
   %td
     -if change.approver
       =change.format_approver_name

--- a/app/views/changes/_table_header.haml
+++ b/app/views/changes/_table_header.haml
@@ -3,6 +3,7 @@
     %tr
       %th Change
       %th When
+      %th PaperTrail::Versions
       %th Approved?
       -if user_can_edit?
         %th Undo?

--- a/db/migrate/20171231030837_add_user_to_changes.rb
+++ b/db/migrate/20171231030837_add_user_to_changes.rb
@@ -1,0 +1,5 @@
+class AddUserToChanges < ActiveRecord::Migration
+  def change
+    add_column :changes, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171022020010) do
+ActiveRecord::Schema.define(version: 20171231030837) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "trackable_id",   limit: 4
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 20171022020010) do
     t.datetime "approved_at"
     t.string   "change_type",           limit: 255
     t.integer  "user_changed_taxon_id", limit: 4
+    t.integer  "user_id",               limit: 4
   end
 
   add_index "changes", ["approver_id"], name: "index_changes_on_approver_id", using: :btree

--- a/features/step_definitions/changes_steps.rb
+++ b/features/step_definitions/changes_steps.rb
@@ -7,7 +7,8 @@ Given(/^there is a genus "([^"]*)" that's waiting for approval$/) do |name|
   genus = create_genus name
   genus.taxon_state.update_columns review_state: :waiting
 
-  change = create :change, user_changed_taxon_id: genus.id
+  # TODO: Do not use `User.first` or `User.first.id`.
+  change = create :change, user_changed_taxon_id: genus.id, user: User.first
   whodunnit = User.first.id
   create :version, item_id: genus.id, whodunnit: whodunnit, change_id: change.id
 

--- a/lib/undo_tracker.rb
+++ b/lib/undo_tracker.rb
@@ -1,9 +1,8 @@
 class UndoTracker
-  # TODO associate the change with the current_user instead of getting that
-  # from the versions. `User.current` *may* be useful for this.
-  # TODO maybe rename -- this *creates* the change.
+  # TODO: Maybe rename -- this *creates* the change.
+  # TODO: Pass `user` from controllers.
   def self.setup_change taxon, change_type
-    change = Change.create! change_type: change_type, user_changed_taxon_id: taxon.id
+    change = Change.create! change_type: change_type, user_changed_taxon_id: taxon.id, user: User.current
     RequestStore.store[:current_change_id] = change.id
     change
   end

--- a/spec/factories/changes.rb
+++ b/spec/factories/changes.rb
@@ -4,15 +4,15 @@ FactoryGirl.define do
   end
 end
 
-def setup_version taxon, whodunnit = nil
-  change = create :change, user_changed_taxon_id: taxon.id
+def setup_version taxon, user
+  change = create :change, user_changed_taxon_id: taxon.id, user: user
 
   create :version,
     item_id: taxon.id,
     event: 'create',
     item_type: 'Taxon',
     change_id: change.id,
-    whodunnit: whodunnit.try(:id)
+    whodunnit: user.id
   change
 end
 
@@ -21,7 +21,7 @@ def create_taxon_version_and_change review_state, user = @user, approver = nil, 
   taxon = create :genus, name: name
   taxon.taxon_state.review_state = review_state
 
-  change = create :change, user_changed_taxon_id: taxon.id, change_type: "create"
+  change = create :change, user_changed_taxon_id: taxon.id, change_type: "create", user: user
   create :version, item_id: taxon.id, whodunnit: user.id, change_id: change.id
 
   if approver

--- a/spec/models/change_spec.rb
+++ b/spec/models/change_spec.rb
@@ -1,10 +1,12 @@
 require 'spec_helper'
 
 describe Change, versioning: true do
+  let(:user) { create :user }
+
   describe 'relationships' do
     it "has a version" do
       genus = create_genus
-      change = described_class.new
+      change = described_class.new user: user
       change.save!
       change.reload
       create :version, item: genus, change_id: change.id
@@ -23,16 +25,16 @@ describe Change, versioning: true do
       before do
         genus_1 = create_genus
         genus_1.taxon_state.update review_state: 'waiting'
-        @unreviewed_change = setup_version genus_1
+        @unreviewed_change = setup_version genus_1, user
 
         genus_2 = create_genus
         genus_2.taxon_state.update review_state: 'approved'
-        approved_earlier_change = setup_version genus_2
+        approved_earlier_change = setup_version genus_2, user
         approved_earlier_change.update approved_at: (Date.today - 7)
 
         genus_2 = create_genus
         genus_2.taxon_state.update review_state: 'approved'
-        approved_later_change = setup_version genus_2
+        approved_later_change = setup_version genus_2, user
         approved_later_change.update approved_at: (Date.today + 7)
       end
 

--- a/spec/models/taxa/taxon_workflow_spec.rb
+++ b/spec/models/taxa/taxon_workflow_spec.rb
@@ -86,13 +86,14 @@ describe Taxon do
   describe "Last change and version", versioning: true do
     describe "#last_change" do
       let(:taxon) { create_genus }
+      let(:user) { create :user }
 
       it "returns nil if no Changes have been created for it" do
         expect(taxon.last_change).to be_nil
       end
 
       it "returns the Change, if any" do
-        change = setup_version taxon
+        change = setup_version taxon, user
         expect(taxon.last_change).to eq change
       end
     end


### PR DESCRIPTION
Issue: #359 

So I looked into this and the reason we're showing the wrong editor is because to find the editor responsible for the change, the code looks for the editor in PaperTrail versions associated with the change. If there are no such versions (for example if you just save the form without making any changes), the code searches in the history of the taxon, which is why we always get the second most recent editor when this happens.

Changes:

* For new edits: Directly associate the correct user with the change.
* For old edits: Remove backwards compatability code so that we're not showing the wrong editor (it will just say "Someone" instead)
* For debugging purposes: Show the number of PaperTrail versions in the change list, so that we can figure out if A) we should not create these changes in the first place because nothing was changed, or B) make sure all changes are associated with the correct `change_id`.