### PR TITLE
Tech: 2.5.4 tweaks

### DIFF
--- a/app/assets/javascripts/all_pages/global.coffee
+++ b/app/assets/javascripts/all_pages/global.coffee
@@ -51,3 +51,38 @@ AntCat.allowSpacesWhileAutocompleting = (flag, subtext) ->
     match[2] || match[1]
   else
     null
+
+# Toggle "show more" / "Show less".
+$ ->
+  SHOW_CHARS = 500
+  MORE_TEXT = 'Show more'
+  LESS_TEXT = 'Show less'
+
+  $('.more').each ->
+    content = $(this).html()
+    if content.length > SHOW_CHARS
+      beforeTruncation = content.substr(0, SHOW_CHARS)
+      truncated = content.substr(SHOW_CHARS, content.length - SHOW_CHARS)
+
+      html = """
+        #{beforeTruncation}
+        <span>... &nbsp;</span>
+        <span class="more-content">
+          <span>#{truncated}</span>
+          &nbsp;&nbsp;
+          <a href="" class="btn-normal btn-tiny more-link">#{MORE_TEXT}</a>
+        </span>
+      """
+      $(this).html html
+
+  $('.more-link').click (event) ->
+    event.preventDefault()
+
+    if $(this).hasClass('less')
+      $(this).removeClass 'less'
+      $(this).html MORE_TEXT
+    else
+      $(this).addClass 'less'
+      $(this).html LESS_TEXT
+    $(this).parent().prev().toggle()
+    $(this).prev().toggle()

--- a/app/assets/stylesheets/site/_global.sass
+++ b/app/assets/stylesheets/site/_global.sass
@@ -110,3 +110,6 @@ table td.shrink
   padding: 0.5rem
   font-size: 1rem
   background-color: #ddd
+
+.more-content span
+  display: none

--- a/app/database_scripts/database_scripts/taxa_with_type_fields.rb
+++ b/app/database_scripts/database_scripts/taxa_with_type_fields.rb
@@ -75,5 +75,5 @@ description: >
   See [Edit institutions](/institutions) for all
   a list of all institutions.
 
-tags: [new!, slow]
+tags: [slow]
 topic_areas: [types]

--- a/app/decorators/activity_decorator.rb
+++ b/app/decorators/activity_decorator.rb
@@ -5,7 +5,7 @@ class ActivityDecorator < Draper::Decorator
   # Activities are by default associated with the performing user, but
   # in the console and other situations we may not have a current user.
   def link_user
-    return "[system]" unless user
+    return '' unless user
     user.decorate.user_page_link
   end
 

--- a/app/decorators/reference_decorator/nested_reference_decorator.rb
+++ b/app/decorators/reference_decorator/nested_reference_decorator.rb
@@ -5,4 +5,10 @@ class NestedReferenceDecorator < ReferenceDecorator
     def format_citation
       "#{h pages_in} #{nesting_reference.decorate.formatted}".html_safe
     end
+
+    # Fall back to nesting reference's PDF is nestee does not have one.
+    def pdf_link
+      super unless reference.downloadable?
+      helpers.link_to 'PDF', reference.url
+    end
 end

--- a/app/services/exporters/antweb/type_fields.rb
+++ b/app/services/exporters/antweb/type_fields.rb
@@ -19,12 +19,12 @@ class Exporters::Antweb::TypeFields
 
     def published_type_information
       return unless taxon.published_type_information.present?
-      add_period_if_necessary detax(taxon.published_type_information)
+      add_period_if_necessary "Primary type information: #{detax(taxon.published_type_information)}"
     end
 
     def additional_type_information
       return unless taxon.additional_type_information.present?
-      add_period_if_necessary "Additional type information: #{detax(taxon.additional_type_information)}"
+      add_period_if_necessary "Secondary type information: #{detax(taxon.additional_type_information)}"
     end
 
     def type_notes

--- a/app/views/activities/templates/_feedback.haml
+++ b/app/views/activities/templates/_feedback.haml
@@ -1,5 +1,5 @@
 -unless activity.user
-  an unregistered user
+  An unregistered user
 
 =activity.action_to_verb
 the feedback item

--- a/app/views/catalog/_type_fields.haml
+++ b/app/views/catalog/_type_fields.haml
@@ -1,14 +1,14 @@
 #type-fields
   -if taxon.published_type_information.present?
-    %span
+    %span.more
       =add_period_if_necessary ::Types::FormatTypeField[taxon.published_type_information]
 
   -if taxon.additional_type_information.present?
-    %span
+    %span.more
       %strong Additional type information:
       =add_period_if_necessary ::Types::FormatTypeField[taxon.additional_type_information]
 
   -if taxon.type_notes.present?
-    %span
+    %span.more
       %strong Type notes:
       =add_period_if_necessary ::Types::FormatTypeField[taxon.type_notes]

--- a/app/views/catalog/_type_fields.haml
+++ b/app/views/catalog/_type_fields.haml
@@ -1,11 +1,12 @@
 #type-fields
   -if taxon.published_type_information.present?
     %span.more
+      %strong Primary type information:
       =add_period_if_necessary ::Types::FormatTypeField[taxon.published_type_information]
 
   -if taxon.additional_type_information.present?
     %span.more
-      %strong Additional type information:
+      %strong Secondary type information:
       =add_period_if_necessary ::Types::FormatTypeField[taxon.additional_type_information]
 
   -if taxon.type_notes.present?

--- a/app/views/editors_panels/index.haml
+++ b/app/views/editors_panels/index.haml
@@ -32,9 +32,7 @@
       %li=link_to "Markdown formatting help", markdown_formatting_help_path
       %li=link_to "History item search", taxon_history_items_path
       %li=link_to "Reference section search", reference_sections_path
-      %li
-        =link_to "Edit institutions", institutions_path
-        =new_label
+      %li=link_to "Edit institutions", institutions_path
 
   .large-3.medium-4.columns
     -if current_user

--- a/app/views/pages/lazy_links.html.haml
+++ b/app/views/pages/lazy_links.html.haml
@@ -29,7 +29,6 @@
   .medium-3.columns
     %h5 Test pages
     %ul
-      %li=link_to "New Relic", "/newrelic"
       %li=link_to "name_popup", widget_tests_name_popup_test_path
       %li=link_to "name_field", widget_tests_name_field_test_path
       %li=link_to "reference_popup", widget_tests_reference_popup_test_path
@@ -40,5 +39,4 @@
   .medium-3.columns
     %h5 Misc.
     %ul
-      %li=link_to "New Relic", "/newrelic"
       %li=link_to "Routes", "/rails/info/routes"

--- a/app/views/taxa/form/_type_section.haml
+++ b/app/views/taxa/form/_type_section.haml
@@ -2,12 +2,13 @@
   %h5.callout-header Type
   %table.unstriped.no-border
     -if taxon.kind_of? SpeciesGroupTaxon
+      -# TODO: Rename columns in database to match view.
       %tr
-        %td.caption=form.label :original_published_type_information
+        %td.caption=form.label :primary_type_information
         %td#published_type_information_taxt_editor.taxt_editor
           =render 'taxt_editors/show', name: 'taxon[published_type_information]', value: TaxtConverter[taxon.published_type_information].to_editor_format
       %tr
-        %td.caption=form.label :additional_type_information
+        %td.caption=form.label :secondary_type_information
         %td#additional_type_information_taxt_editor.taxt_editor
           =render 'taxt_editors/show', name: 'taxon[additional_type_information]', value: TaxtConverter[taxon.additional_type_information].to_editor_format
       %tr

--- a/features/feed/feedback_activities.feature
+++ b/features/feed/feedback_activities.feature
@@ -5,7 +5,7 @@ Feature: Feed (feedback)
     And I log in as a catalog editor named "Archibald"
 
     When I go to the activity feed
-    Then I should see "[system] an unregistered user added the feedback item #"
+    Then I should see "An unregistered user added the feedback item #"
 
   Scenario: Added feedback (registered user)
     Given I log in as a catalog editor named "Archibald"

--- a/features/feed/user_activities.feature
+++ b/features/feed/user_activities.feature
@@ -8,4 +8,4 @@ Feature: Feed (users)
       And I fill in "user_password_confirmation" with "secret123"
       And I press "Sign Up"
     And I go to the activity feed
-    Then I should see "[system] Quintus Batiatus registered an account, welcome to antcat.org!" and no other feed items
+    Then I should see "Quintus Batiatus registered an account, welcome to antcat.org!" and no other feed items

--- a/spec/decorators/activity_decorator_spec.rb
+++ b/spec/decorators/activity_decorator_spec.rb
@@ -14,7 +14,7 @@ describe ActivityDecorator do
       let(:activity) { create :activity, user: nil }
 
       it "handles nil / 'system' activities" do
-        expect(activity.decorate.link_user).to include "[system]"
+        expect(activity.decorate.link_user).to eq ""
       end
     end
   end


### PR DESCRIPTION
#### Show more / show less
Truncates any type field at 500 characters (the limit is set to 200 in the screenshots, and "Primary type information" is not included since that change had not been done at the time the screenshots were taken).

![showmo](https://user-images.githubusercontent.com/1513381/34631602-693b84f2-f271-11e7-8578-eedab0deb47c.png)
![showle](https://user-images.githubusercontent.com/1513381/34631603-695d2a6c-f271-11e7-875a-f34a4c22fb3d.png)

#### Include the heading "Primary type information"
![typeinfo](https://user-images.githubusercontent.com/1513381/34631601-691b6db6-f271-11e7-8a4b-2fd421b3779d.png)
  
Also closes #370.