### PR TITLE
New reference selector

### DIFF
--- a/app/assets/javascripts/controllers/taxa/form/form.coffee
+++ b/app/assets/javascripts/controllers/taxa/form/form.coffee
@@ -37,7 +37,6 @@ class AntCat.TaxonForm extends AntCat.Form
     if $('#type_name_field').size() == 1
       new AntCat.TypeNameField $('#type_name_field'), protonym_field, value_id: 'taxon_type_name_attributes_id', parent_form: @, allow_blank: true
       new AntCat.TaxtEditor $('#type_taxt_editor'), parent_buttons: '.buttons_section'
-    new AntCat.ReferenceField $('#authorship_field'), parent_form: @, value_id: 'taxon_protonym_attributes_authorship_attributes_reference_attributes_id'
 
   initialize_parent_section: =>
     options = {}

--- a/app/assets/javascripts/reference_select.coffee
+++ b/app/assets/javascripts/reference_select.coffee
@@ -1,0 +1,26 @@
+$ ->
+  REFERENCE_SELECT_SELECTOR = 'select[data-reference-select]'
+  $(REFERENCE_SELECT_SELECTOR).each -> $(this).referenceSelectify()
+
+$.fn.referenceSelectify = ->
+  selectElement = this
+  $(selectElement).select2
+    theme: 'bootstrap'
+    templateResult: (item) ->
+      return if item.loading
+      "<small>##{item.id}</small> #{item.author} (#{item.year}) <small>#{item.title}</small>"
+    templateSelection: (item) ->
+      return '(none)' unless item.id
+      author = $(selectElement).data 'author'
+      year = $(selectElement).data 'year'
+      title = $(selectElement).data 'title'
+      "<small>##{item.id}</small> #{item.author || author} (#{item.year || year}) <small>#{item.title || title}</small>"
+    escapeMarkup: (m) -> m
+    minimumInputLength: 1
+    placeholder: '???'
+    allowClear: true
+    ajax:
+      url: '/references/autocomplete'
+      dataType: 'json'
+      data: (params) -> { qq: params.term }
+      processResults: (data) -> { results: data }

--- a/app/assets/javascripts/widgets/reference_field.coffee
+++ b/app/assets/javascripts/widgets/reference_field.coffee
@@ -1,3 +1,5 @@
+# TODO not use, will be removed.
+
 class AntCat.ReferenceField extends AntCat.ReferencePicker
   constructor: (@parent_element, @options = {}) ->
     @options.click_on_display = true

--- a/app/assets/stylesheets/controllers/_taxa.sass
+++ b/app/assets/stylesheets/controllers/_taxa.sass
@@ -28,8 +28,6 @@
     .protonym_section
       #protonym_name_field
         display: inline-block
-      #authorship_field
-        display: inline-block
       .locality
         @extend %fix-typeahead-display
 

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -75,7 +75,7 @@ class ReferencesController < ApplicationController
   end
 
   def autocomplete
-    search_query = params[:q] || ''
+    search_query = params[:q] || params[:qq] || ''
 
     respond_to do |format|
       format.json do

--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -170,7 +170,7 @@ class TaxaController < ApplicationController
                 :forms,
                 :notes_taxt,
                 :id,
-                { reference_attributes: [:id] }
+                :reference_id
               ]
             }
           ]

--- a/app/helpers/reference_select_helper.rb
+++ b/app/helpers/reference_select_helper.rb
@@ -1,0 +1,31 @@
+module ReferenceSelectHelper
+  private
+    def reference_data_attributes reference
+      for_reference = if reference
+                        {
+                          title: reference.title,
+                          author: reference.author_names_string,
+                          year: reference.citation_year,
+                        }
+                      end
+
+      { reference_select: true }.merge(for_reference || {})
+    end
+
+  module FormBuilderAdditions
+    include ActionView::Helpers::FormOptionsHelper
+    include ReferenceSelectHelper
+
+    def reference_select reference_attribute_name
+      reference = object.send reference_attribute_name
+      reference_id = reference.try(:id)
+
+      self.select "#{reference_attribute_name}_id".to_sym,
+        options_for_select([reference_id].compact, reference_id),
+        { include_blank: '(none)' },
+        class: 'select2-autocomplete', data: reference_data_attributes(reference)
+    end
+  end
+end
+
+ActionView::Helpers::FormBuilder.send(:include, ReferenceSelectHelper::FormBuilderAdditions)

--- a/app/services/autocomplete/autocomplete_references.rb
+++ b/app/services/autocomplete/autocomplete_references.rb
@@ -8,13 +8,14 @@ module Autocomplete
 
     def call
       search_results.map do |reference|
-        search_query = if keyword_params.size == 1 # size 1 = no keyword params were matched
+        search_query = if keyword_params.size == 1 # size 1 == no keyword params were matched.
                          reference.title
                        else
                          format_autosuggest_keywords reference, keyword_params
                        end
         {
           search_query: search_query,
+          id: reference.id,
           title: reference.title,
           author: reference.author_names_string,
           year: reference.citation_year
@@ -27,7 +28,14 @@ module Autocomplete
       attr_reader :search_query
 
       def search_results
-        ::References::Search::Fulltext[search_options]
+        exact_id_match || ::References::Search::Fulltext[search_options]
+      end
+
+      def exact_id_match
+        return unless search_query =~ /^\d{6} ?$/
+
+        match = Reference.find_by id: search_query
+        [match] if match
       end
 
       def search_options

--- a/app/services/autocomplete/autocomplete_references.rb
+++ b/app/services/autocomplete/autocomplete_references.rb
@@ -39,7 +39,7 @@ module Autocomplete
       end
 
       def search_options
-        { reference_type: :nomissing, items_per_page: 5 }.merge keyword_params
+        { reference_type: :nomissing, items_per_page: 15 }.merge keyword_params
       end
 
       def keyword_params

--- a/app/services/taxa/save_from_form.rb
+++ b/app/services/taxa/save_from_form.rb
@@ -65,7 +65,6 @@ class Taxa::SaveFromForm
       return unless taxon.protonym.authorship
 
       attributes = authorship_attributes
-      attributes[:reference_id] = attributes.delete(:reference_attributes)[:id]
       return if attributes[:reference_id].blank? && taxon.protonym.authorship.reference.blank?
 
       taxon.protonym.authorship.attributes = attributes

--- a/app/views/taxa/_form.haml
+++ b/app/views/taxa/_form.haml
@@ -12,7 +12,7 @@
   =javascript_include_tag 'widgets/reference_popup', 'widgets/name_popup', 'widgets/taxt_editor'
   =javascript_include_tag 'controllers/taxa/form/_bundle'
   =javascript_include_tag 'controllers/taxa/not_really_form/_bundle'
-  =javascript_include_tag 'taxon_select', 'markdown_and_friends', 'taxt_editor'
+  =javascript_include_tag 'taxon_select', 'reference_select', 'markdown_and_friends', 'taxt_editor'
 
 =render 'shared/taxt_editor/taxon_and_ancestors', taxon: @taxon
 

--- a/app/views/taxa/form/_protonym_section.haml
+++ b/app/views/taxa/form/_protonym_section.haml
@@ -22,8 +22,8 @@
           =protonym_form.check_box :sic
           =protonym_form.label :sic
 
-      %tr
-        =protonym_form.fields_for :authorship do |authorship_form|
+      =protonym_form.fields_for :authorship do |authorship_form|
+        %tr
           %td.caption
             =authorship_form.label :reference do
               Authorship
@@ -34,28 +34,28 @@
             =hidden_field_tag 'taxon[protonym_attributes][authorship_attributes][reference_attributes][id]', authorship_form.object.reference.try(:id),
                 id: 'taxon_protonym_attributes_authorship_attributes_reference_attributes_id'
 
+        %tr
+          %td.caption
+            =authorship_form.label :pages do
+              Pages
+              =tooltip_icon "pages", scope: :taxa
+          %td=authorship_form.text_field :pages
+
+        -unless taxon.is_a? Tribe
           %tr
             %td.caption
-              =authorship_form.label :pages do
-                Pages
-                =tooltip_icon "pages", scope: :taxa
-            %td=authorship_form.text_field :pages
-
-          -unless taxon.is_a? Tribe
-            %tr
-              %td.caption
-                =authorship_form.label :forms do
-                  Forms
-                  =tooltip_icon "forms", scope: :taxa
-              %td=authorship_form.text_field :forms
-
-            %tr
-              %td.caption
-                =protonym_form.label :locality do
-                  Locality
-                  =tooltip_icon "locality", scope: :taxa
-              %td=protonym_form.text_field :locality
+              =authorship_form.label :forms do
+                Forms
+                =tooltip_icon "forms", scope: :taxa
+            %td=authorship_form.text_field :forms
 
           %tr
-            %td.caption=form.label :notes_taxt, 'Notes'
-            %td=render 'shared/taxt_editor/template', name: 'taxon[protonym_attributes][authorship_attributes][notes_taxt]', content: taxon.protonym.authorship.notes_taxt, id: :taxon_protonym_attributes_authorship_attributes_notes_taxt
+            %td.caption
+              =protonym_form.label :locality do
+                Locality
+                =tooltip_icon "locality", scope: :taxa
+            %td=protonym_form.text_field :locality
+
+        %tr
+          %td.caption=form.label :notes_taxt, 'Notes'
+          %td=render 'shared/taxt_editor/template', name: 'taxon[protonym_attributes][authorship_attributes][notes_taxt]', content: taxon.protonym.authorship.notes_taxt, id: :taxon_protonym_attributes_authorship_attributes_notes_taxt

--- a/app/views/taxa/form/_protonym_section.haml
+++ b/app/views/taxa/form/_protonym_section.haml
@@ -28,11 +28,7 @@
             =authorship_form.label :reference do
               Authorship
               =tooltip_icon "authorship", scope: :taxa
-          %td
-            #authorship_field
-              =render 'reference_fields/show', references: nil, reference: authorship_form.object.reference
-            =hidden_field_tag 'taxon[protonym_attributes][authorship_attributes][reference_attributes][id]', authorship_form.object.reference.try(:id),
-                id: 'taxon_protonym_attributes_authorship_attributes_reference_attributes_id'
+          %td=authorship_form.reference_select :reference
 
         %tr
           %td.caption

--- a/features/changes/changes.feature
+++ b/features/changes/changes.feature
@@ -20,10 +20,7 @@ Feature: Changes
     And I click the protonym name field
     And I set the protonym name to "Eciton"
     And I press "OK"
-    And I click the authorship field
-    And in the reference picker, I search for the author "Fisher"
-    And I click the first search result
-    And I press "OK"
+    And I set the authorship to the first search results of "Fisher (2004)"
     And I click the type name field
     And I set the type name to "Atta major"
     And I press "OK"

--- a/features/feed/taxon_activities.feature
+++ b/features/feed/taxon_activities.feature
@@ -8,6 +8,9 @@ Feature: Feed (taxa)
     Given activity tracking is disabled
       And there is a subfamily "Formicinae"
       And there is a genus "Eciton"
+      And this reference exists
+        | authors | citation   | title | year |
+        | Fisher  | Psyche 3:3 | Ants  | 2004 |
     And activity tracking is enabled
 
     When I go to the catalog page for "Formicinae"
@@ -18,10 +21,7 @@ Feature: Feed (taxa)
         And I click the protonym name field
           And I set the protonym name to "Eciton"
           And I press "OK"
-        And I click the authorship field
-          And in the reference picker, I search for the author "Fisher"
-          And I click the first search result
-          And I press "OK"
+        And I set the authorship to the first search results of "Fisher (2004)"
         And I click the type name field
           And I set the type name to "Atta major"
           And I press "OK"

--- a/features/step_definitions/edit_steps/edit_steps.rb
+++ b/features/step_definitions/edit_steps/edit_steps.rb
@@ -8,7 +8,7 @@ def select2(value, from:)
 
   first("#select2-#{element_id}-container").click
   first('.select2-search__field').set(value)
-  find(".select2-results__option", text: /#{value}/).click
+  find(".select2-results__option", text: /#{Regexp.escape(value)}/).click
 end
 
 When("I press the edit taxon link") do
@@ -120,8 +120,14 @@ When("I set the homonym replaced by name to {string}") do |name|
 end
 
 ### authorship
-When("I click the authorship field") do
-  step %(I click "#authorship_field .display_button")
+When(/^I set the authorship to the first search results of "([^"]*)"$/) do |name|
+  select2 name, from: 'taxon_protonym_attributes_authorship_attributes_reference_id'
+end
+
+Then(/^the authorship should contain the reference "([^"]*)"$/) do |keey|
+  reference_id = find_reference_by_keey(keey).id
+  selector = '#taxon_protonym_attributes_authorship_attributes_reference_id'
+  expect(find(selector).value).to eq reference_id.to_s
 end
 
 When("I fill in the authorship notes with {string}") do |notes|

--- a/features/taxon_form/add_taxon_successfully.feature
+++ b/features/taxon_form/add_taxon_successfully.feature
@@ -27,11 +27,8 @@ Feature: Adding a taxon successfully
 
     When I set the protonym name to "Eciton"
       And I press "OK"
-    And I click the authorship field
-      And in the reference picker, I search for the author "Fisher"
-      And I click the first search result
-    And I press "OK"
-    When I click the type name field
+    And I set the authorship to the first search results of "Fisher (2004)"
+    And I click the type name field
     Then the type name field should contain "Eciton "
 
     When I set the type name to "Atta major"
@@ -56,10 +53,7 @@ Feature: Adding a taxon successfully
     And I click the protonym name field
       And I set the protonym name to "Eciton"
       And I press "OK"
-    And I click the authorship field
-      And in the reference picker, I search for the author "Fisher"
-      And I click the first search result
-      And I press "OK"
+    And I set the authorship to the first search results of "Fisher (2004)"
     And I click the type name field
       And I set the type name to "Eciton major"
       And I press "OK"
@@ -85,11 +79,8 @@ Feature: Adding a taxon successfully
     When I set the protonym name to "Mayria"
       And I press "OK"
       And I press "Add this name"
-    And I click the authorship field
-      And in the reference picker, I search for the author "Fisher"
-      And I click the first search result
-    And I press "OK"
-    When I click the type name field
+    And I set the authorship to the first search results of "Fisher (2004)"
+    And I click the type name field
     Then the type name field should contain "Mayria "
 
     When I set the type name to "Mayria madagascarensis"
@@ -126,10 +117,7 @@ Feature: Adding a taxon successfully
     And I click the protonym name field
       And I set the protonym name to "Eciton major"
       And I press "OK"
-    And I click the authorship field
-      And in the reference picker, I search for the author "Fisher"
-      And I click the first search result
-      And I press "OK"
+    And I set the authorship to the first search results of "Fisher (2004)"
     And I save my changes
     Then I should be on the catalog page for "Eciton major"
     And I should see "Eciton major" in the protonym
@@ -157,10 +145,7 @@ Feature: Adding a taxon successfully
     And I click the protonym name field
     And I set the protonym name to "Dolichoderus (Subdolichoderus) major"
     And I press "OK"
-    And I click the authorship field
-    And in the reference picker, I search for the author "Fisher"
-    And I click the first search result
-    And I press "OK"
+    And I set the authorship to the first search results of "Fisher (2004)"
     And I save my changes
     Then I should be on the catalog page for "Dolichoderus (Subdolichoderus) major"
     And I should see "Dolichoderus (Subdolichoderus) major" in the protonym
@@ -175,10 +160,7 @@ Feature: Adding a taxon successfully
     And I click the protonym name field
       And I set the protonym name to "Atta"
       And I press "OK"
-    And I click the authorship field
-      And in the reference picker, I search for the author "Fisher"
-      And I click the first search result
-      And I press "OK"
+    And I set the authorship to the first search results of "Fisher (2004)"
     And I click the type name field
       And I set the type name to "Atta major"
       And I press "OK"
@@ -188,16 +170,13 @@ Feature: Adding a taxon successfully
     And the changes are approved
     And I go to the catalog page for "Atta"
     And I follow "Add species"
-    When I click the name field
+    And I click the name field
       And I set the name to "Atta major"
       And I press "OK"
     And I click the protonym name field
       And I set the protonym name to "Atta major"
       And I press "OK"
-    And I click the authorship field
-      And in the reference picker, I search for the author "Fisher"
-      And I click the first search result
-      And I press "OK"
+    And I set the authorship to the first search results of "Fisher (2004)"
     And I save my changes
     And I wait
     Then I should be on the catalog page for "Atta major"
@@ -220,10 +199,7 @@ Feature: Adding a taxon successfully
     And I click the protonym name field
       And I set the protonym name to "Eciton major infra"
       And I press "OK"
-    And I click the authorship field
-      And in the reference picker, I search for the author "Fisher"
-      And I click the first search result
-      And I press "OK"
+    And I set the authorship to the first search results of "Fisher (2004)"
     And I save my changes
     Then I should be on the catalog page for "Eciton major infra"
     And I should see "infra" in the index
@@ -240,15 +216,12 @@ Feature: Adding a taxon successfully
     When I click the name field
       And I set the name to "Dorylinae"
       And I press "OK"
-    When I click the protonym name field
+    And I click the protonym name field
     Then the protonym name field should contain "Dorylinae"
 
     When I press "OK"
-    And I click the authorship field
-      And in the reference picker, I search for the author "Fisher"
-      And I click the first search result
-      And I press "OK"
-    When I click the type name field
+    And I set the authorship to the first search results of "Fisher (2004)"
+    And I click the type name field
     Then the type name field should contain "Dorylinae "
 
     When I set the type name to "Atta"
@@ -276,10 +249,7 @@ Feature: Adding a taxon successfully
     Then the protonym name field should contain "Dorylini"
 
     When I press "OK"
-    And I click the authorship field
-      And in the reference picker, I search for the author "Fisher"
-      And I click the first search result
-      And I press "OK"
+    And I set the authorship to the first search results of "Fisher (2004)"
     And I save my changes
     Then I should be on the catalog page for "Dorylini"
       And I should see "Dorylini" in the protonym

--- a/features/taxon_form/edit_taxon.feature
+++ b/features/taxon_form/edit_taxon.feature
@@ -33,11 +33,8 @@ Feature: Editing a taxon
     And there is a genus "Eciton"
 
     When I go to the edit page for "Eciton"
-    And I click the authorship field
-    And in the reference picker, I search for the author "Fisher"
-    And I click the first search result
-    And I press "OK"
-    Then the authorship field should contain "Fisher 2004. Ants. Psyche 3:3"
+    And I set the authorship to the first search results of "Fisher (2004)"
+    Then the authorship should contain the reference "Fisher 2004"
 
     When I fill in the authorship notes with "Authorship notes"
     And I fill in "taxon_type_taxt" with "Notes"

--- a/features/widgets/default_reference.feature
+++ b/features/widgets/default_reference.feature
@@ -12,7 +12,7 @@ Feature: Using the default reference
 
     When I go to the catalog page for "Atta"
     And I follow "Add species"
-    Then the authorship field should contain "Ward, P.S. 2010. Annals of Ants. Psyche 1:1."
+    Then the authorship should contain the reference "Ward 2010"
 
   Scenario: Using the default reference in the reference popup
     Given the default reference is "Ward 2010"

--- a/spec/services/taxa/save_from_form_spec.rb
+++ b/spec/services/taxa/save_from_form_spec.rb
@@ -282,7 +282,7 @@ def taxon_params
       sic:              '0',
       locality:         '',
       authorship_attributes: {
-        reference_attributes: { id: reference.id },
+        reference_id: reference.id,
         pages: '',
         forms: '',
         notes_taxt: ''


### PR DESCRIPTION
This is for reference buttons (protonym reference etc); the reference selector in the taxt editor will be updated in #377.

![refwip](https://user-images.githubusercontent.com/1513381/34739592-11689562-f57d-11e7-99a8-ce973d99c85d.png)

Closes: #117.