### PR TITLE
Refactor reference-related

### DIFF
--- a/app/assets/javascripts/controllers/references/search_form/all_fields_autocompletion.coffee
+++ b/app/assets/javascripts/controllers/references/search_form/all_fields_autocompletion.coffee
@@ -24,6 +24,6 @@ $ ->
         '</div>'
       suggestion: (reference) ->
         '<p>' + reference.author + ' (' + reference.year + ')<br><small>' + reference.title + '</small></p>'
-        # Note: `reference.author` is generated from `Reference.author_names_string`.
+        # Note: `reference.author` is generated from `Reference.author_names_string_with_suffix`.
 
   $('input.typeahead-references-js').typeahead options, dataSet

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -130,6 +130,7 @@ class ReferencesController < ApplicationController
         :nesting_reference_id,
         :citation,
         :author_names_string,
+        :author_names_suffix,
         { document_attributes: [:id, :file, :url, :public] }
       )
     end

--- a/app/decorators/reference_decorator.rb
+++ b/app/decorators/reference_decorator.rb
@@ -57,7 +57,7 @@ class ReferenceDecorator < ApplicationDecorator
   private
 
     def generate_plain_text
-      string = make_html_safe(reference.author_names_string.dup)
+      string = make_html_safe(reference.author_names_string_with_suffix)
       string << ' ' unless string.empty?
       string << make_html_safe(reference.citation_year) << '. '
       string << format_title << ' '

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -115,7 +115,7 @@ class ReferenceForm
     end
 
     def check_for_duplicates!
-      duplicates = References::MatchReferences[@reference, min_similarity: 0.5]
+      duplicates = References::FindDuplicates[@reference, min_similarity: 0.5]
       return if duplicates.blank?
 
       duplicate = Reference.find duplicates.first[:match].id

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -65,7 +65,7 @@ class ReferenceForm
       string = params.delete(:author_names_string)
       return if string.strip == @reference.author_names_string
 
-      author_names = Authors::FindOrCreateNamesFromString[string.dup][:author_names]
+      author_names = Authors::FindOrCreateNamesFromString[string.dup]
 
       if author_names.empty? && string.present?
         @reference.errors.add :author_names_string, "couldn't be parsed."

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -63,12 +63,11 @@ class ReferenceForm
 
     def parse_author_names_string
       string = params.delete(:author_names_string)
-      return if string == @reference.author_names_string
+      return if string.strip == @reference.author_names_string
 
-      author_names_and_suffix = @reference.parse_author_names_and_suffix string
+      author_names = @reference.parse_author_names string
       @reference.author_names.clear
-      params[:author_names] = author_names_and_suffix[:author_names]
-      params[:author_names_suffix] = author_names_and_suffix[:author_names_suffix]
+      params[:author_names] = author_names
     end
 
     def set_journal

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -65,7 +65,14 @@ class ReferenceForm
       string = params.delete(:author_names_string)
       return if string.strip == @reference.author_names_string
 
-      author_names = @reference.parse_author_names string
+      author_names = Authors::FindOrCreateNamesFromString[string.dup][:author_names]
+
+      if author_names.empty? && string.present?
+        @reference.errors.add :author_names_string, "couldn't be parsed."
+        @reference.author_names_string_cache = string
+        raise ActiveRecord::RecordInvalid, @reference
+      end
+
       @reference.author_names.clear
       params[:author_names] = author_names
     end

--- a/app/helpers/reference_select_helper.rb
+++ b/app/helpers/reference_select_helper.rb
@@ -5,7 +5,7 @@ module ReferenceSelectHelper
       for_reference = if reference
                         {
                           title: reference.title,
-                          author: reference.author_names_string,
+                          author: reference.author_names_string_with_suffix,
                           year: reference.citation_year
                         }
                       end

--- a/app/models/author_name.rb
+++ b/app/models/author_name.rb
@@ -11,21 +11,6 @@ class AuthorName < ApplicationRecord
 
   has_paper_trail meta: { change_id: proc { UndoTracker.get_current_change_id } }
 
-  # TODO rename.
-  def self.import data
-    data.map do |name|
-      all.where(name: name).find { |possible_name| possible_name.name == name } ||
-        create!(name: name, author: Author.create!)
-    end
-  end
-
-  def self.import_author_names_string string
-    author_data = Parsers::AuthorParser.parse!(string)
-    { author_names: import(author_data[:names]), author_names_suffix: author_data[:suffix] }
-  rescue Citrus::ParseError
-    { author_names: [], author_names_suffix: nil }
-  end
-
   def last_name
     name_parts[:last]
   end

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -102,16 +102,6 @@ class Reference < ApplicationRecord
     update_attribute :author_names_string_cache, make_author_names_string_cache
   end
 
-  def parse_author_names author_names_string
-    author_names = AuthorName.import_author_names_string(author_names_string.dup)[:author_names]
-    if author_names.empty? && author_names_string.present?
-      errors.add :author_names_string, "couldn't be parsed."
-      self.author_names_string_cache = author_names_string
-      raise ActiveRecord::RecordInvalid, self
-    end
-    author_names
-  end
-
   def check_for_duplicate
     duplicates = References::MatchReferences[self, min_similarity: 0.5]
     return if duplicates.blank?

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -102,18 +102,6 @@ class Reference < ApplicationRecord
     update_attribute :author_names_string_cache, make_author_names_string_cache
   end
 
-  def check_for_duplicate
-    duplicates = References::MatchReferences[self, min_similarity: 0.5]
-    return if duplicates.blank?
-
-    duplicate = Reference.find duplicates.first[:match].id
-    errors.add :base, <<~MSG.html_safe
-      This may be a duplicate of #{duplicate.decorate.plain_text} #{duplicate.id}.<br>
-      To save, click "Save Anyway"
-    MSG
-    true
-  end
-
   # TODO merge into Workflow. Only used for `.approve_all`,
   # which approves all unreviewed references of any state (which Workflow doesn't allow).
   def approve

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -40,7 +40,7 @@ class Reference < ApplicationRecord
   has_paper_trail meta: { change_id: proc { UndoTracker.get_current_change_id } }
   strip_attributes only: [:editor_notes, :public_notes, :taxonomic_notes, :title,
     :citation, :date, :citation_year, :series_volume_issue, :pagination,
-    :pages_in, :doi, :reason_missing, :review_state, :bolton_key], replace_newlines: true
+    :pages_in, :doi, :reason_missing, :review_state, :bolton_key, :author_names_suffix], replace_newlines: true
   tracked on: :mixin_create_activity_only, parameters: proc { { name: keey } }
 
   searchable do
@@ -83,6 +83,12 @@ class Reference < ApplicationRecord
     author_names_string_cache
   end
 
+  def author_names_string_with_suffix
+    string = make_author_names_string_cache
+    string << " #{author_names_suffix}" if author_names_suffix.present?
+    string
+  end
+
   # TODO we should probably have `#year` [int] and something
   # like `#non_standard_year` [string] instead of this +
   # `#year` + `#citation_year`.
@@ -92,20 +98,18 @@ class Reference < ApplicationRecord
     citation_year.gsub %r{ .*$}, ''
   end
 
-  # TODO does this duplicate `set_author_names_caches`?
-  # There's also `#author_names_string=` which sets `#author_names_string_cache`.
   def refresh_author_names_caches(*)
     update_attribute :author_names_string_cache, make_author_names_string_cache
   end
 
-  def parse_author_names_and_suffix author_names_string
-    author_names_and_suffix = AuthorName.import_author_names_string author_names_string.dup
-    if author_names_and_suffix[:author_names].empty? && author_names_string.present?
+  def parse_author_names author_names_string
+    author_names = AuthorName.import_author_names_string(author_names_string.dup)[:author_names]
+    if author_names.empty? && author_names_string.present?
       errors.add :author_names_string, "couldn't be parsed."
       self.author_names_string_cache = author_names_string
       raise ActiveRecord::RecordInvalid, self
     end
-    author_names_and_suffix
+    author_names
   end
 
   def check_for_duplicate
@@ -190,14 +194,11 @@ class Reference < ApplicationRecord
       # rubocop:enable Lint/AssignmentInCondition
     end
 
-    # TODO does this duplicate `refresh_author_names_caches`?
     def set_author_names_caches(*)
       self.author_names_string_cache = make_author_names_string_cache
     end
 
     def make_author_names_string_cache
-      string = author_names.map(&:name).join('; ')
-      string << author_names_suffix if author_names_suffix.present?
-      string
+      author_names.map(&:name).join('; ').strip
     end
 end

--- a/app/models/references/article_reference.rb
+++ b/app/models/references/article_reference.rb
@@ -4,16 +4,6 @@ class ArticleReference < Reference
   validates :year, :journal, :series_volume_issue, :pagination, presence: true
 
   # TODO not used (since at least December 2016).
-  def start_page
-    page_parts[:start]
-  end
-
-  # TODO not used (since at least December 2016).
-  def end_page
-    page_parts[:end]
-  end
-
-  # TODO not used (since at least December 2016).
   def series
     series_volume_issue_parts[:series]
   end
@@ -30,9 +20,5 @@ class ArticleReference < Reference
 
     def series_volume_issue_parts
       @series_volume_issue_parts ||= Parsers::ArticleCitationParser.get_series_volume_issue_parts series_volume_issue
-    end
-
-    def page_parts
-      @page_parts ||= Parsers::ArticleCitationParser.get_page_parts pagination
     end
 end

--- a/app/services/authors/find_or_create_names_from_string.rb
+++ b/app/services/authors/find_or_create_names_from_string.rb
@@ -1,0 +1,32 @@
+module Authors
+  class FindOrCreateNamesFromString
+    include Service
+
+    def initialize string
+      @string = string
+    end
+
+    def call
+      import_author_names_string
+    end
+
+    private
+
+      attr_reader :string
+
+      # TODO rename.
+      def import data
+        data.map do |name|
+          AuthorName.all.where(name: name).find { |possible_name| possible_name.name == name } ||
+            AuthorName.create!(name: name, author: Author.create!)
+        end
+      end
+
+      def import_author_names_string
+        author_data = Parsers::AuthorParser.parse!(string)
+        { author_names: import(author_data[:names]), author_names_suffix: author_data[:suffix] }
+      rescue Citrus::ParseError
+        { author_names: [], author_names_suffix: nil }
+      end
+  end
+end

--- a/app/services/authors/find_or_create_names_from_string.rb
+++ b/app/services/authors/find_or_create_names_from_string.rb
@@ -7,20 +7,15 @@ module Authors
     end
 
     def call
-      import
+      parsed_author_names.map do |name|
+        AuthorName.where(name: name).find { |case_sensitive_name| case_sensitive_name.name == name } ||
+          AuthorName.create!(name: name, author: Author.create!)
+      end
     end
 
     private
 
       attr_reader :string
-
-      # TODO rename.
-      def import
-        parsed_author_names.map do |name|
-          AuthorName.all.where(name: name).find { |possible_name| possible_name.name == name } ||
-            AuthorName.create!(name: name, author: Author.create!)
-        end
-      end
 
       def parsed_author_names
         Parsers::AuthorParser.parse!(string)

--- a/app/services/authors/find_or_create_names_from_string.rb
+++ b/app/services/authors/find_or_create_names_from_string.rb
@@ -7,7 +7,7 @@ module Authors
     end
 
     def call
-      import_author_names_string
+      import
     end
 
     private
@@ -15,18 +15,17 @@ module Authors
       attr_reader :string
 
       # TODO rename.
-      def import data
-        data.map do |name|
+      def import
+        parsed_author_names.map do |name|
           AuthorName.all.where(name: name).find { |possible_name| possible_name.name == name } ||
             AuthorName.create!(name: name, author: Author.create!)
         end
       end
 
-      def import_author_names_string
-        author_data = Parsers::AuthorParser.parse!(string)
-        { author_names: import(author_data[:names]), author_names_suffix: author_data[:suffix] }
+      def parsed_author_names
+        Parsers::AuthorParser.parse!(string)
       rescue Citrus::ParseError
-        { author_names: [], author_names_suffix: nil }
+        []
       end
   end
 end

--- a/app/services/autocomplete/autocomplete_linkable_references.rb
+++ b/app/services/autocomplete/autocomplete_linkable_references.rb
@@ -10,7 +10,7 @@ module Autocomplete
       search_results.map do |reference|
         {
           id: reference.id,
-          author: reference.author_names_string,
+          author: reference.author_names_string_with_suffix,
           year: reference.citation_year,
           title: reference.decorate.format_title,
           full_pagination: full_pagination(reference),

--- a/app/services/autocomplete/autocomplete_references.rb
+++ b/app/services/autocomplete/autocomplete_references.rb
@@ -17,7 +17,7 @@ module Autocomplete
           search_query: search_query,
           id: reference.id,
           title: reference.title,
-          author: reference.author_names_string,
+          author: reference.author_names_string_with_suffix,
           year: reference.citation_year
         }
       end

--- a/app/services/parsers/article_citation_parser.rb
+++ b/app/services/parsers/article_citation_parser.rb
@@ -8,13 +8,4 @@ module Parsers::ArticleCitationParser
     parts[:issue] = matches[3].match(/\((\w+)\)/)[1] if matches[3].present?
     parts
   end
-
-  def self.get_page_parts string
-    parts = {}
-    return parts unless string
-    matches = string.match(/(.+?)(?:-(.+?))?\.?$/) or return parts
-    parts[:start] = matches[1]
-    parts[:end] = matches[2] if matches[2].present?
-    parts
-  end
 end

--- a/app/services/parsers/author_parser.rb
+++ b/app/services/parsers/author_parser.rb
@@ -3,13 +3,13 @@ Citrus.load "#{__dir__}/author_grammar", force: true unless defined? Parsers::Au
 
 module Parsers::AuthorParser
   def self.parse! string
-    return { names: [] } if string.blank?
+    return [] if string.blank?
 
     match = Parsers::AuthorGrammar.parse(string, consume: false)
     result = match.value
     string.gsub! /#{Regexp.escape match}/, ''
 
-    { names: result[:names], suffix: result[:suffix] }
+    result[:names]
   end
 
   def self.parse string

--- a/app/services/references/find_duplicates.rb
+++ b/app/services/references/find_duplicates.rb
@@ -1,5 +1,5 @@
 module References
-  class MatchReferences
+  class FindDuplicates
     include Service
 
     def initialize target, min_similarity: 0.01

--- a/app/services/references/search/author_search.rb
+++ b/app/services/references/search/author_search.rb
@@ -28,7 +28,7 @@ module References
         end
 
         def author_names
-          Parsers::AuthorParser.parse(search_query)[:names]
+          Parsers::AuthorParser.parse(search_query)
         end
     end
   end

--- a/app/views/references/_form.haml
+++ b/app/views/references/_form.haml
@@ -12,11 +12,16 @@
   =render 'shared/errors_for', resource: reference
 
   .row
-    .medium-6.columns
+    .medium-4.columns
       =label_tag :reference_author_names_string do
         Authors
         =tooltip_icon :authors, scope: :references
       =f.text_field :author_names_string
+    .medium-2.columns
+      =label_tag :author_names_suffix do
+        Authors suffix
+        =tooltip_icon :author_names_suffix, scope: :references
+      =f.select :author_names_suffix, Reference.distinct.pluck(:author_names_suffix)
     .medium-1.columns
       =label_tag :reference_citation_year, 'Year'
       =f.text_field :citation_year

--- a/spec/models/author_name_spec.rb
+++ b/spec/models/author_name_spec.rb
@@ -6,72 +6,12 @@ describe AuthorName do
   it { is_expected.to validate_presence_of :name }
   it { is_expected.to validate_uniqueness_of :name }
 
-  describe "#import" do
-    context 'when authors does not exists' do
-      it "creates and returns the authors" do
-        results = described_class.import ['Fisher, B.L.', 'Wheeler, W.M.']
-        expect(results.map(&:name)).to match_array ['Fisher, B.L.', 'Wheeler, W.M.']
-      end
-    end
-
-    context 'when authors already exists' do
-      before { described_class.import ['Fisher, B.L.', 'Wheeler, W.M.'] }
-
-      it "reuses existing authors" do
-        expect { described_class.import ['Fisher, B.L.', 'Wheeler, W.M.'] }.
-          not_to change { described_class.count }.from(2)
-      end
-    end
-
-    it "is case sensitive" do
-      described_class.import ['Mackay, W. M.', 'MacKay, W. M.']
-      expect(described_class.count).to eq 2
-    end
-  end
-
   describe "editing" do
     it "updates associated references when the name is changed" do
       author_name = create :author_name, name: 'Ward'
       reference = create :reference, author_names: [author_name]
       author_name.update name: 'Fisher'
       expect(reference.reload.author_names_string).to eq 'Fisher'
-    end
-  end
-
-  describe "#import_author_names_string" do
-    it "finds or creates authors with names in the string" do
-      described_class.create! name: 'Bolton, B.', author: Author.create!
-      author_data = described_class.import_author_names_string 'Ward, P.S.; Bolton, B.'
-      expect(author_data[:author_names].first.name).to eq 'Ward, P.S.'
-      expect(author_data[:author_names].second.name).to eq 'Bolton, B.'
-      expect(author_data[:author_names_suffix]).to be_nil
-      expect(described_class.count).to eq 2
-    end
-
-    it "returns the authors suffix" do
-      author_data = described_class.import_author_names_string 'Ward, P.S.; Bolton, B. (eds.)'
-      expect(author_data[:author_names].first.name).to eq 'Ward, P.S.'
-      expect(author_data[:author_names].second.name).to eq 'Bolton, B.'
-      expect(author_data[:author_names_suffix]).to eq ' (eds.)'
-    end
-
-    it "handles 'the Andres'" do
-      author_data = described_class.import_author_names_string 'Andre, Edm.; Andre, Ern.'
-      expect(author_data[:author_names].first.name).to eq 'Andre, Edm.'
-      expect(author_data[:author_names].second.name).to eq 'Andre, Ern.'
-    end
-
-    it "handles invalid input" do
-      author_data = described_class.import_author_names_string ' ; '
-      expect(author_data[:author_names]).to eq []
-      expect(author_data[:author_names_suffix]).to be_nil
-    end
-
-    it "handles a semicolon followed by a space at the end" do
-      author_data = described_class.import_author_names_string 'Ward, P. S.; '
-      expect(author_data[:author_names].size).to eq 1
-      expect(author_data[:author_names].first.name).to eq 'Ward, P. S.'
-      expect(author_data[:author_names_suffix]).to be_nil
     end
   end
 

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -29,35 +29,6 @@ describe Reference do
     end
   end
 
-  describe "#parse_author_names" do
-    let(:reference) { build_stubbed :reference }
-
-    context 'when input in empty' do
-      it "returns nothing" do
-        expect(reference.parse_author_names('')).to eq []
-      end
-    end
-
-    context 'when input is invalid' do
-      it "adds an error and raise an exception" do
-        expect { reference.parse_author_names('...asdf sdf dsfdsf') }.
-          to raise_error ActiveRecord::RecordInvalid
-        expect(reference.errors.messages).to eq author_names_string: ["couldn't be parsed."]
-        expect(reference.author_names_string).to eq '...asdf sdf dsfdsf'
-      end
-    end
-
-    context 'when input is valid' do
-      it "returns the author names" do
-        results = reference.parse_author_names 'Fisher, B.; Bolton, B.'
-        fisher = AuthorName.find_by(name: 'Fisher, B.')
-        bolton = AuthorName.find_by(name: 'Bolton, B.')
-
-        expect(results).to eq [fisher, bolton]
-      end
-    end
-  end
-
   describe "#author_names_string_with_suffix" do
     describe "formatting" do
       it "consists of one author_name if that's all there is" do

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -146,43 +146,6 @@ describe Reference do
     end
   end
 
-  describe "duplicate checking" do
-    let(:reference_params) do
-      {
-        author_names: [fisher_bl],
-        citation_year: '1981',
-        title: 'Dolichoderinae',
-        journal: create(:journal),
-        series_volume_issue: '1(2)',
-        pagination: '22-54'
-      }
-    end
-    let!(:original) { ArticleReference.create! reference_params }
-
-    describe 'implementing MatchReferences' do
-      it 'maps all fields correctly' do
-        expect(original.principal_author_last_name).to eq 'Fisher'
-        expect(original.year).to eq 1981
-        expect(original.title).to eq 'Dolichoderinae'
-        expect(original.type).to eq 'ArticleReference'
-        expect(original.series_volume_issue).to eq '1(2)'
-        expect(original.pagination).to eq '22-54'
-      end
-    end
-
-    it "allows a duplicate record to be saved" do
-      expect { ArticleReference.create! reference_params }.not_to raise_error
-    end
-
-    it "checks possible duplication and add to errors, if any found" do
-      duplicate = ArticleReference.create! reference_params
-
-      expect(duplicate.errors).to be_empty
-      expect(duplicate.check_for_duplicate).to be_truthy
-      expect(duplicate.errors).not_to be_empty
-    end
-  end
-
   describe "#short_citation_year" do
     it "is the same as citation year if nothing extra" do
       reference = build_stubbed :article_reference, citation_year: '1970'

--- a/spec/models/references/article_reference_spec.rb
+++ b/spec/models/references/article_reference_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe ArticleReference do
-  let(:reference) { build_stubbed :article_reference }
-
   it { is_expected.to validate_presence_of :year }
   it { is_expected.to validate_presence_of :series_volume_issue }
   it { is_expected.to validate_presence_of :journal }
   it { is_expected.to validate_presence_of :pagination }
 
   describe "parsing fields from series_volume_issue" do
+    let(:reference) { build_stubbed :article_reference }
+
     it "can extract volume and issue" do
       reference.series_volume_issue = "92(32)"
       expect(reference.volume).to eq '92'
@@ -26,20 +26,6 @@ describe ArticleReference do
       expect(reference.series).to eq 'I'
       expect(reference.volume).to eq 'C'
       expect(reference.issue).to eq 'xix'
-    end
-  end
-
-  describe "parsing fields from pagination" do
-    it "can extract beginning and ending page numbers" do
-      reference.pagination = '163-181'
-      expect(reference.start_page).to eq '163'
-      expect(reference.end_page).to eq '181'
-    end
-
-    it "can extract single page numbers" do
-      reference.pagination = "8"
-      expect(reference.start_page).to eq '8'
-      expect(reference.end_page).to be_nil
     end
   end
 end

--- a/spec/services/authors/find_or_create_names_from_string_spec.rb
+++ b/spec/services/authors/find_or_create_names_from_string_spec.rb
@@ -5,36 +5,32 @@ describe Authors::FindOrCreateNamesFromString do
     it "finds or creates authors with names in the string" do
       AuthorName.create! name: 'Bolton, B.', author: Author.create!
       author_data = described_class['Ward, P.S.; Bolton, B.']
-      expect(author_data[:author_names].first.name).to eq 'Ward, P.S.'
-      expect(author_data[:author_names].second.name).to eq 'Bolton, B.'
-      expect(author_data[:author_names_suffix]).to be_nil
+      expect(author_data.first.name).to eq 'Ward, P.S.'
+      expect(author_data.second.name).to eq 'Bolton, B.'
       expect(AuthorName.count).to eq 2
     end
 
     it "returns the authors suffix" do
       author_data = described_class['Ward, P.S.; Bolton, B. (eds.)']
-      expect(author_data[:author_names].first.name).to eq 'Ward, P.S.'
-      expect(author_data[:author_names].second.name).to eq 'Bolton, B.'
-      expect(author_data[:author_names_suffix]).to eq ' (eds.)'
+      expect(author_data.first.name).to eq 'Ward, P.S.'
+      expect(author_data.second.name).to eq 'Bolton, B.'
     end
 
     it "handles 'the Andres'" do
       author_data = described_class['Andre, Edm.; Andre, Ern.']
-      expect(author_data[:author_names].first.name).to eq 'Andre, Edm.'
-      expect(author_data[:author_names].second.name).to eq 'Andre, Ern.'
+      expect(author_data.first.name).to eq 'Andre, Edm.'
+      expect(author_data.second.name).to eq 'Andre, Ern.'
     end
 
     it "handles invalid input" do
       author_data = described_class[' ; ']
-      expect(author_data[:author_names]).to eq []
-      expect(author_data[:author_names_suffix]).to be_nil
+      expect(author_data).to eq []
     end
 
     it "handles a semicolon followed by a space at the end" do
       author_data = described_class['Ward, P. S.; ']
-      expect(author_data[:author_names].size).to eq 1
-      expect(author_data[:author_names].first.name).to eq 'Ward, P. S.'
-      expect(author_data[:author_names_suffix]).to be_nil
+      expect(author_data.size).to eq 1
+      expect(author_data.first.name).to eq 'Ward, P. S.'
     end
   end
 end

--- a/spec/services/authors/find_or_create_names_from_string_spec.rb
+++ b/spec/services/authors/find_or_create_names_from_string_spec.rb
@@ -4,33 +4,33 @@ describe Authors::FindOrCreateNamesFromString do
   describe "#call" do
     it "finds or creates authors with names in the string" do
       AuthorName.create! name: 'Bolton, B.', author: Author.create!
-      author_data = described_class['Ward, P.S.; Bolton, B.']
-      expect(author_data.first.name).to eq 'Ward, P.S.'
-      expect(author_data.second.name).to eq 'Bolton, B.'
+      author_names = described_class['Ward, P.S.; Bolton, B.']
+      expect(author_names.first.name).to eq 'Ward, P.S.'
+      expect(author_names.second.name).to eq 'Bolton, B.'
       expect(AuthorName.count).to eq 2
     end
 
     it "returns the authors suffix" do
-      author_data = described_class['Ward, P.S.; Bolton, B. (eds.)']
-      expect(author_data.first.name).to eq 'Ward, P.S.'
-      expect(author_data.second.name).to eq 'Bolton, B.'
+      author_names = described_class['Ward, P.S.; Bolton, B. (eds.)']
+      expect(author_names.first.name).to eq 'Ward, P.S.'
+      expect(author_names.second.name).to eq 'Bolton, B.'
     end
 
     it "handles 'the Andres'" do
-      author_data = described_class['Andre, Edm.; Andre, Ern.']
-      expect(author_data.first.name).to eq 'Andre, Edm.'
-      expect(author_data.second.name).to eq 'Andre, Ern.'
+      author_names = described_class['Andre, Edm.; Andre, Ern.']
+      expect(author_names.first.name).to eq 'Andre, Edm.'
+      expect(author_names.second.name).to eq 'Andre, Ern.'
     end
 
     it "handles invalid input" do
-      author_data = described_class[' ; ']
-      expect(author_data).to eq []
+      author_names = described_class[' ; ']
+      expect(author_names).to eq []
     end
 
     it "handles a semicolon followed by a space at the end" do
-      author_data = described_class['Ward, P. S.; ']
-      expect(author_data.size).to eq 1
-      expect(author_data.first.name).to eq 'Ward, P. S.'
+      author_names = described_class['Ward, P. S.; ']
+      expect(author_names.size).to eq 1
+      expect(author_names.first.name).to eq 'Ward, P. S.'
     end
   end
 end

--- a/spec/services/authors/find_or_create_names_from_string_spec.rb
+++ b/spec/services/authors/find_or_create_names_from_string_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+describe Authors::FindOrCreateNamesFromString do
+  describe "#call" do
+    it "finds or creates authors with names in the string" do
+      AuthorName.create! name: 'Bolton, B.', author: Author.create!
+      author_data = described_class['Ward, P.S.; Bolton, B.']
+      expect(author_data[:author_names].first.name).to eq 'Ward, P.S.'
+      expect(author_data[:author_names].second.name).to eq 'Bolton, B.'
+      expect(author_data[:author_names_suffix]).to be_nil
+      expect(AuthorName.count).to eq 2
+    end
+
+    it "returns the authors suffix" do
+      author_data = described_class['Ward, P.S.; Bolton, B. (eds.)']
+      expect(author_data[:author_names].first.name).to eq 'Ward, P.S.'
+      expect(author_data[:author_names].second.name).to eq 'Bolton, B.'
+      expect(author_data[:author_names_suffix]).to eq ' (eds.)'
+    end
+
+    it "handles 'the Andres'" do
+      author_data = described_class['Andre, Edm.; Andre, Ern.']
+      expect(author_data[:author_names].first.name).to eq 'Andre, Edm.'
+      expect(author_data[:author_names].second.name).to eq 'Andre, Ern.'
+    end
+
+    it "handles invalid input" do
+      author_data = described_class[' ; ']
+      expect(author_data[:author_names]).to eq []
+      expect(author_data[:author_names_suffix]).to be_nil
+    end
+
+    it "handles a semicolon followed by a space at the end" do
+      author_data = described_class['Ward, P. S.; ']
+      expect(author_data[:author_names].size).to eq 1
+      expect(author_data[:author_names].first.name).to eq 'Ward, P. S.'
+      expect(author_data[:author_names_suffix]).to be_nil
+    end
+  end
+end

--- a/spec/services/autocomplete/autocomplete_linkable_references_spec.rb
+++ b/spec/services/autocomplete/autocomplete_linkable_references_spec.rb
@@ -17,7 +17,7 @@ describe Autocomplete::AutocompleteLinkableReferences do
         expect(service.call).to eq [
           {
             id: reference.id,
-            author: reference.author_names_string,
+            author: reference.author_names_string_with_suffix,
             year: reference.citation_year,
             title: "#{reference.title}.",
             full_pagination: "[pagination: #{reference.pages_in} (22 pp.)]",

--- a/spec/services/parsers/article_citation_parser_spec.rb
+++ b/spec/services/parsers/article_citation_parser_spec.rb
@@ -19,14 +19,4 @@ describe Parsers::ArticleCitationParser do
         to eq series: 'I', volume: 'C', issue: 'xix'
     end
   end
-
-  describe "#get_page_parts" do
-    it "can parse beginning and ending page numbers" do
-      expect(parser.get_page_parts('163-181')).to eq start: '163', end: '181'
-    end
-
-    it "can parse just a single page number" do
-      expect(parser.get_page_parts('8')).to eq start: '8'
-    end
-  end
 end

--- a/spec/services/parsers/author_parser_spec.rb
+++ b/spec/services/parsers/author_parser_spec.rb
@@ -7,161 +7,127 @@ describe Parsers::AuthorParser do
     describe "Modifying the input string" do
       it "modifies the string if the bang version is used" do
         string = 'Fisher, B.L.'
-        expect(parser.parse!(string)[:names]).to eq ['Fisher, B.L.']
+        expect(parser.parse!(string)).to eq ['Fisher, B.L.']
         expect(string).to eq ''
       end
 
       it "doesn't modify the string if the bang version is not used" do
         string = 'Fisher, B.L.'
-        expect(parser.parse(string)[:names]).to eq ['Fisher, B.L.']
+        expect(parser.parse(string)).to eq ['Fisher, B.L.']
         expect(string).to eq 'Fisher, B.L.'
       end
     end
 
     it "returns an empty array if the string is empty" do
-      expect(parser.parse('')[:names]).to eq []
-      expect(parser.parse(nil)[:names]).to eq []
+      expect(parser.parse('')).to eq []
+      expect(parser.parse(nil)).to eq []
     end
 
     it "parses a single author into a one-element array" do
       string = 'Fisher, B.L.'
-      expect(parser.parse!(string)[:names]).to eq ['Fisher, B.L.']
-      expect(string).to eq ''
-    end
-
-    it "parses a single author + author roles into a hash" do
-      string = 'Fisher, B.L. (ed.)'
-      result = parser.parse! string
-      expect(result).to eq names: ['Fisher, B.L.'], suffix: ' (ed.)'
-      expect(result[:suffix].class).to eq String
+      expect(parser.parse!(string)).to eq ['Fisher, B.L.']
       expect(string).to eq ''
     end
 
     it "parses multiple authors" do
       string = 'Fisher, B.L.; Wheeler, W.M.'
-      expect(parser.parse!(string)[:names]).to eq ['Fisher, B.L.', 'Wheeler, W.M.']
+      expect(parser.parse!(string)).to eq ['Fisher, B.L.', 'Wheeler, W.M.']
       expect(string).to eq ''
     end
 
-    it "parses multiple authors with a role" do
-      expect(parser.parse("Breed, M. D.; Page, R. E. (eds.)")).
-        to eq names: ['Breed, M. D.', 'Page, R. E.'], suffix: ' (eds.)'
-    end
-
     it "handles names with hyphens" do
-      expect(parser.parse('Abdul-Rassoul, M.S.')[:names]).to eq ['Abdul-Rassoul, M.S.']
+      expect(parser.parse('Abdul-Rassoul, M.S.')).to eq ['Abdul-Rassoul, M.S.']
     end
 
     it "handles a name with two last names" do
-      expect(parser.parse('Baroni Urbani, C.')[:names]).to eq ['Baroni Urbani, C.']
+      expect(parser.parse('Baroni Urbani, C.')).to eq ['Baroni Urbani, C.']
     end
 
     it "handles a name with an apostrophe" do
-      expect(parser.parse("Passerin d'Entrèves, P.")[:names]).to eq ["Passerin d'Entrèves, P."]
+      expect(parser.parse("Passerin d'Entrèves, P.")).to eq ["Passerin d'Entrèves, P."]
     end
 
     it "handles a name with an initial without a period, as long as it's before a semicolon" do
-      expect(parser.parse("Sanetra, M; Ward, P.")[:names]).to eq ['Sanetra, M', 'Ward, P.']
-    end
-
-    it "handles 'et al.' without a comma before it" do
-      expect(parser.parse("Sanetra, M; Ward, P. et al.")).
-        to eq names: ['Sanetra, M', 'Ward, P.'], suffix: ' et al.'
-    end
-
-    it "handles 'et al.' with a comma before it" do
-      expect(parser.parse("Sanetra, M; Ward, P., et al.")).
-        to eq names: ['Sanetra, M', 'Ward, P.'], suffix: ', et al.'
-    end
-
-    it "handles 'et al. (eds.)'" do
-      expect(parser.parse("Sanetra, M; Ward, P., et al. (eds.)")).
-        to eq names: ['Sanetra, M', 'Ward, P.'], suffix: ', et al. (eds.)'
-    end
-
-    it "strips the space after the suffix" do
-      string = "Sanetra, M; Ward, P., et al. (eds.) Ants"
-      parser.parse! string
-      expect(string).to eq 'Ants'
+      expect(parser.parse("Sanetra, M; Ward, P.")).to eq ['Sanetra, M', 'Ward, P.']
     end
 
     it "handles generation numbers" do
-      expect(parser.parse("Coody, C. J.; Watkins, J. F., II")[:names]).
+      expect(parser.parse("Coody, C. J.; Watkins, J. F., II")).
         to eq ["Coody, C. J.", "Watkins, J. F., II"]
     end
 
     it "handles St." do
-      expect(parser.parse("St. Romain, M. K.")[:names]).to eq ["St. Romain, M. K."]
+      expect(parser.parse("St. Romain, M. K.")).to eq ["St. Romain, M. K."]
     end
 
     it "handles a name with one letter in part of it (not an abbreviation)" do
-      expect(parser.parse("Suñer i Escriche, D.")[:names]).to eq ["Suñer i Escriche, D."]
+      expect(parser.parse("Suñer i Escriche, D.")).to eq ["Suñer i Escriche, D."]
     end
 
     it "handles hyphenated first names" do
-      expect(parser.parse("Kim, J-H.; Park, S.-J.; Kim, B.-J.")[:names]).
+      expect(parser.parse("Kim, J-H.; Park, S.-J.; Kim, B.-J.")).
         to eq ["Kim, J-H.", "Park, S.-J.", "Kim, B.-J."]
     end
 
     it "handles 'da' at the end of a name" do
-      expect(parser.parse("Silva, R. R. da; Lopes, B. C.")[:names]).
+      expect(parser.parse("Silva, R. R. da; Lopes, B. C.")).
         to eq ['Silva, R. R. da', 'Lopes, B. C.']
     end
 
     it "handles 'dos' in the middle of a name" do
-      expect(parser.parse("Feitosa, R. dos S. M.")[:names]).to eq ['Feitosa, R. dos S. M.']
+      expect(parser.parse("Feitosa, R. dos S. M.")).to eq ['Feitosa, R. dos S. M.']
     end
 
     it "handle 'da' at the beginning of a name" do
-      expect(parser.parse("da Silva, R. R.")[:names]).to eq ['da Silva, R. R.']
+      expect(parser.parse("da Silva, R. R.")).to eq ['da Silva, R. R.']
     end
 
     it "handles authors separated by commas" do
-      expect(parser.parse("Breed, M. D., Page, R. E., Ward, P.S.")[:names]).
+      expect(parser.parse("Breed, M. D., Page, R. E., Ward, P.S.")).
         to eq ['Breed, M. D.', 'Page, R. E.', 'Ward, P.S.']
     end
 
     it "handles 'Jr.'" do
       string = 'Brown, W. L., Jr.; Kempf, W. W.'
-      expect(parser.parse!(string)[:names]).to eq ['Brown, W. L., Jr.', 'Kempf, W. W.']
+      expect(parser.parse!(string)).to eq ['Brown, W. L., Jr.', 'Kempf, W. W.']
       expect(string).to eq ''
     end
 
     it "handles 'Sr.'" do
       string = 'Brown, W. L., Sr.'
-      expect(parser.parse!(string)[:names]).to eq ['Brown, W. L., Sr.']
+      expect(parser.parse!(string)).to eq ['Brown, W. L., Sr.']
       expect(string).to eq ''
     end
 
     it "handles 'III'" do
       string = 'Morrison, W.R., III'
-      expect(parser.parse!(string)[:names]).to eq ['Morrison, W.R., III']
+      expect(parser.parse!(string)).to eq ['Morrison, W.R., III']
       expect(string).to eq ''
     end
 
     it "handles 'Jr'" do
       string = 'Brown, W. L., Jr; Kempf, W. W.'
-      expect(parser.parse!(string)[:names]).to eq ['Brown, W. L., Jr', 'Kempf, W. W.']
+      expect(parser.parse!(string)).to eq ['Brown, W. L., Jr', 'Kempf, W. W.']
       expect(string).to eq ''
     end
 
     it "handles a phrase that's known to be an author" do
-      create :author_name, name: 'Anonymous', verified: true
+      create :author_name, name: 'Anonymous'
       string = 'Anonymous'
-      expect(parser.parse!(string)[:names]).to eq ['Anonymous']
+      expect(parser.parse!(string)).to eq ['Anonymous']
       expect(string).to be_empty
     end
 
     it "parses this weird one" do
-      expect(parser.parse('Arias P., T. M.')[:names]).to eq ['Arias P., T. M.']
+      expect(parser.parse('Arias P., T. M.')).to eq ['Arias P., T. M.']
     end
 
     it "handles a semicolon followed by a space at the end" do
-      expect(parser.parse('Ward, P. S.; ')).to eq names: ['Ward, P. S.'], suffix: nil
+      expect(parser.parse('Ward, P. S.; ')).to eq ['Ward, P. S.']
     end
 
     it "handles an authors list separated by ampersand" do
-      expect(parser.parse('Espadaler & DuMerle')).to eq names: ['Espadaler', 'DuMerle'], suffix: nil
+      expect(parser.parse('Espadaler & DuMerle')).to eq ['Espadaler', 'DuMerle']
     end
   end
 

--- a/spec/services/references/find_duplicates_spec.rb
+++ b/spec/services/references/find_duplicates_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe References::MatchReferences do
+describe References::FindDuplicates do
   let(:reference_similarity) { double }
 
   before do


### PR DESCRIPTION
TODO:
- [ ] Create tooltip: `references.author_names_suffix` - Avoid "et al." if possible and include all authors instead.


