### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/app/decorators/reference_decorator.rb
+++ b/app/decorators/reference_decorator.rb
@@ -141,7 +141,7 @@ class ReferenceDecorator < ApplicationDecorator
 
     def doi_link
       return unless reference.doi?
-      helpers.link_to reference.doi, ("http://dx.doi.org/" + doi)
+      helpers.link_to reference.doi, ("https://doi.org/" + doi)
     end
 
     def pdf_link

--- a/spec/decorators/reference_decorator/article_reference_decorator_spec.rb
+++ b/spec/decorators/reference_decorator/article_reference_decorator_spec.rb
@@ -38,7 +38,7 @@ describe ArticleReferenceDecorator do
           %{<a title="Latreille, P. A. 1809. Atta. #{reference.journal.name} (1):3." class="expandable-reference-key" href="#">Latreille, 1809</a>} +
           %(<span class="expandable-reference-content">) +
             %{<span class="expandable-reference-text">Latreille, P. A. 1809. <i>Atta</i>. #{reference.journal.name} (1):3.</span> } +
-            %(<a href="http://dx.doi.org/#{reference.doi}">#{reference.doi}</a> ) +
+            %(<a href="https://doi.org/#{reference.doi}">#{reference.doi}</a> ) +
             %(<a href="example.com">PDF</a> ) +
             %(<a class="btn-normal btn-tiny" href="/references/#{reference.id}">#{reference.id}</a>) +
           %(</span>) +

--- a/spec/services/exporters/antweb/export_taxon_spec.rb
+++ b/spec/services/exporters/antweb/export_taxon_spec.rb
@@ -325,7 +325,7 @@ describe Exporters::Antweb::ExportTaxon do
                   %(<a title="#{ref_title_tag}" href="http://antcat.org/references/#{a_reference.id}">) +
                     %(#{ref_author}, #{ref_year}) +
                   %(</a> ) +
-                  %(<a href="http://dx.doi.org/#{ref_doi}">#{ref_doi}</a>) +
+                  %(<a href="https://doi.org/#{ref_doi}">#{ref_doi}</a>) +
                   %(: 766;) +
                 %(</div>) +
               %(</div>) +

--- a/spec/services/exporters/antweb/inline_citation_spec.rb
+++ b/spec/services/exporters/antweb/inline_citation_spec.rb
@@ -24,7 +24,7 @@ describe Exporters::Antweb::InlineCitation do
           expect(described_class[reference]).to eq(
             %{<a title="Latreille, P. A. 1809. Atta. Science (1):3." } +
             %(href="http://antcat.org/references/#{reference.id}">Latreille, 1809</a>) +
-            %( <a href="http://dx.doi.org/#{reference.doi}">#{reference.doi}</a>)
+            %( <a href="https://doi.org/#{reference.doi}">#{reference.doi}</a>)
           )
         end
       end
@@ -36,7 +36,7 @@ describe Exporters::Antweb::InlineCitation do
           expect(described_class[reference]).to eq(
             %{<a title="Latreille, P. A. 1809. Atta. Science (1):3." } +
             %(href="http://antcat.org/references/#{reference.id}">Latreille, 1809</a>) +
-            %( <a href="http://dx.doi.org/#{reference.doi}">#{reference.doi}</a>) +
+            %( <a href="https://doi.org/#{reference.doi}">#{reference.doi}</a>) +
             %( <a href="example.com">PDF</a>)
           )
         end


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to the codes that generates new DOI links.

Cheers!