### PR TITLE
fix: Trim trailing spaces from `Name#name`

### DIFF
--- a/app/controllers/name_fields_controller.rb
+++ b/app/controllers/name_fields_controller.rb
@@ -2,8 +2,8 @@ class NameFieldsController < NamePickersController
   def find
     data = {}
 
-    name_string = params[:name_string]
-    allow_blank = params[:allow_blank].present?
+    name_string = params[:name_string].strip
+    allow_blank = params[:allow_blank].present? # TODO: Remove after migrating `Taxon.type_name` to `Taxon.type_taxon`.
     new_or_homonym = params[:new_or_homonym].present?
 
     confirming_adding_name = params[:confirm_add_name].present?

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -8,7 +8,7 @@ class Name < ApplicationRecord
   after_save :set_taxon_caches
 
   has_paper_trail meta: { change_id: proc { UndoTracker.get_current_change_id } }
-  strip_attributes only: [:gender], replace_newlines: true
+  strip_attributes only: [:name, :gender], replace_newlines: true
 
   # TODO rename to avoid confusing this with [Rails'] dynamic finder methods.
   def self.find_by_name string


### PR DESCRIPTION
Issue: #556

TODO:

- [ ] Run script

```ruby
jonkerz = User.find 60
Activity.execute_script_activity jonkerz, 'Fix trailing spaces in names, see %github556'

Name.where("name LIKE '% '").find_each do |name| name.save end
```