### PR TITLE
Soft-validation and fix random ant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'sunspot_solr', '2.2.0'
 gem 'swagger_ui_engine'
 gem 'twitter-typeahead-rails'
 gem 'unread'
+gem 'validation_scopes'
 gem 'will_paginate'
 gem 'workflow'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,6 +432,8 @@ GEM
     unicode-display_width (1.4.0)
     unread (0.10.1)
       activerecord (>= 3)
+    validation_scopes (0.6.1)
+      activerecord (>= 3, < 6)
     warden (1.2.7)
       rack (>= 1.0)
     webmock (3.4.2)
@@ -517,6 +519,7 @@ DEPENDENCIES
   twitter-typeahead-rails
   uglifier
   unread
+  validation_scopes
   webmock
   will_paginate
   workflow

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -64,7 +64,7 @@ $foundation-palette: (
   primary: $color_primary,
   secondary: #767676,
   success: $color_primary,
-  warning: #cc4b37,
+  warning: #ffae00,
   alert: $color_danger,
 );
 // NOTE changed.

--- a/app/assets/stylesheets/site/_global.sass
+++ b/app/assets/stylesheets/site/_global.sass
@@ -122,5 +122,8 @@ svg.search-icon, .no-left-border-radius
 fieldset
   border-radius: 5px
 
+#soft-validations
+  font-size: 90%
+
 .user-mention
   font-weight: bold

--- a/app/assets/stylesheets/site/_icons.sass
+++ b/app/assets/stylesheets/site/_icons.sass
@@ -81,6 +81,10 @@ table.notifications
     @extend .fa-check
     color: $color_primary
 
+  &.check
+    @extend .fa-check
+    color: $color_primary
+
   &.superadmin
     @extend .fa-unlock-alt
     color: #fff

--- a/app/controllers/catalog/fix_random_controller.rb
+++ b/app/controllers/catalog/fix_random_controller.rb
@@ -1,0 +1,24 @@
+module Catalog
+  class FixRandomController < ApplicationController
+    def show
+      if taxon
+        redirect_to catalog_path(taxon)
+      else
+        redirect_to database_scripts_path, notice: <<~MSG
+          Whaaaat?? All randomizable ants with issues have been fixed!
+          But you may still be able to find more things to fix in this list :)
+        MSG
+      end
+    end
+
+    private
+
+      # HACK: Naive but lazy (not eager) implementation.
+      def taxon
+        @taxon ||= Taxa::CallbacksAndValidations::DATABASE_SCRIPTS_TO_CHECK.
+                     map(&:new).shuffle.lazy.
+                     map { |script| script.results.sample }.
+                     detect { |taxon| taxon }
+      end
+  end
+end

--- a/app/database_scripts/database_scripts/extant_taxa_in_fossil_genera.rb
+++ b/app/database_scripts/database_scripts/extant_taxa_in_fossil_genera.rb
@@ -25,3 +25,4 @@ end
 
 __END__
 topic_areas: [catalog]
+issue_description: The parent of this taxon is fossil, but this taxon is extant.

--- a/app/database_scripts/database_scripts/fossil_taxa_with_biogeographic_regions.rb
+++ b/app/database_scripts/database_scripts/fossil_taxa_with_biogeographic_regions.rb
@@ -9,3 +9,4 @@ end
 __END__
 description: See %github389.
 topic_areas: [catalog]
+issue_description: This taxon is fossil, but is has a biogeographic region.

--- a/app/database_scripts/database_scripts/junior_synonyms_listed_as_another_taxons_senior.rb
+++ b/app/database_scripts/database_scripts/junior_synonyms_listed_as_another_taxons_senior.rb
@@ -9,3 +9,4 @@ end
 __END__
 description: See %github279.
 topic_areas: [synonyms]
+issue_description: This taxon is a junior synonym according to its status, but another taxon shows it as its senior.

--- a/app/database_scripts/database_scripts/junior_synonyms_listed_as_another_taxons_senior.rb
+++ b/app/database_scripts/database_scripts/junior_synonyms_listed_as_another_taxons_senior.rb
@@ -1,7 +1,7 @@
 module DatabaseScripts
   class JuniorSynonymsListedAsAnotherTaxonsSenior < DatabaseScript
     def results
-      Taxon.where(id: Synonym.pluck(:senior_synonym_id)).where(status: Status::SYNONYM)
+      Taxon.where(id: Synonym.select(:senior_synonym_id)).where(status: Status::SYNONYM)
     end
   end
 end

--- a/app/database_scripts/database_scripts/non_homonyms_with_a_homonym_replaced_by_id.rb
+++ b/app/database_scripts/database_scripts/non_homonyms_with_a_homonym_replaced_by_id.rb
@@ -27,3 +27,4 @@ description: >
   Note that the "Replaced by" button in the edit form is only visible when the when
   a taxon's status is set to "homonym".
 topic_areas: [catalog]
+issue_description: This taxon has a "Replaced by" taxon, but its status is not 'homonym'.

--- a/app/database_scripts/database_scripts/pass_through_names_with_synonyms.rb
+++ b/app/database_scripts/database_scripts/pass_through_names_with_synonyms.rb
@@ -19,3 +19,4 @@ description: >
 
 tags: [regression-test]
 topic_areas: [synonyms]
+issue_description: This taxon is a "pass-through name", but is has senior or junior synonyms.

--- a/app/database_scripts/database_scripts/pass_through_names_with_synonyms.rb
+++ b/app/database_scripts/database_scripts/pass_through_names_with_synonyms.rb
@@ -1,18 +1,9 @@
 module DatabaseScripts
   class PassThroughNamesWithSynonyms < DatabaseScript
     def results
-      with_senior_synonyms + with_junior_synonyms
+      Taxon.pass_through_names.left_outer_joins(:junior_synonyms_objects, :senior_synonyms_objects).
+        distinct.where("synonyms.senior_synonym_id IS NOT NULL OR synonyms.junior_synonym_id IS NOT NULL")
     end
-
-    private
-
-      def with_senior_synonyms
-        Taxon.pass_through_names.joins(:senior_synonyms).distinct
-      end
-
-      def with_junior_synonyms
-        Taxon.pass_through_names.joins(:junior_synonyms).distinct
-      end
   end
 end
 

--- a/app/database_scripts/database_scripts/pass_through_names_with_taxts.rb
+++ b/app/database_scripts/database_scripts/pass_through_names_with_taxts.rb
@@ -19,3 +19,4 @@ description: >
   See %github375.
 
 topic_areas: [synonyms]
+issue_description: This taxon is a "pass-through name", but is has history items or reference sections.

--- a/app/database_scripts/database_scripts/pass_through_names_with_taxts.rb
+++ b/app/database_scripts/database_scripts/pass_through_names_with_taxts.rb
@@ -1,18 +1,9 @@
 module DatabaseScripts
   class PassThroughNamesWithTaxts < DatabaseScript
     def results
-      with_history_items + with_reference_sections
+      Taxon.pass_through_names.left_outer_joins(:history_items, :reference_sections).
+        distinct.where("taxon_history_items.id IS NOT NULL OR reference_sections.id IS NOT NULL")
     end
-
-    private
-
-      def with_history_items
-        Taxon.pass_through_names.joins(:history_items).distinct
-      end
-
-      def with_reference_sections
-        Taxon.pass_through_names.joins(:reference_sections).distinct
-      end
   end
 end
 

--- a/app/database_scripts/database_scripts/subspecies_without_species.rb
+++ b/app/database_scripts/database_scripts/subspecies_without_species.rb
@@ -9,3 +9,4 @@ end
 __END__
 description: Auto-generated subspecies are not included.
 topic_areas: [catalog]
+issue_description: This subspecies has no species.

--- a/app/database_scripts/database_scripts/taxa_above_species_with_biogeographic_regions.rb
+++ b/app/database_scripts/database_scripts/taxa_above_species_with_biogeographic_regions.rb
@@ -17,3 +17,4 @@ end
 
 __END__
 topic_areas: [catalog]
+issue_description: This taxon has a biogeographic region, but it is not a species or subspecies.

--- a/app/database_scripts/database_scripts/taxa_above_species_with_biogeographic_regions.rb
+++ b/app/database_scripts/database_scripts/taxa_above_species_with_biogeographic_regions.rb
@@ -7,7 +7,7 @@ module DatabaseScripts
 
     def render
       as_table do |t|
-        t.header :subspecies, :biogeographic_region
+        t.header :taxon, :biogeographic_region
 
         t.rows { |taxon| [markdown_taxon_link(taxon), taxon.biogeographic_region] }
       end

--- a/app/database_scripts/database_scripts/taxa_referencing_non_existing_taxa.rb
+++ b/app/database_scripts/database_scripts/taxa_referencing_non_existing_taxa.rb
@@ -3,15 +3,15 @@ module DatabaseScripts
     include Rails.application.routes.url_helpers
     include ActionView::Helpers::UrlHelper
 
-    def species_id_results
-      Taxon.where('species_id NOT IN (SELECT id FROM taxa)')
+    def results
+      Taxon.where.not(species_id: Taxon.select(:id))
     end
 
     def render
       as_table do |t|
         t.header :non_existing_species_id, :taxon, :status, :search_history?
 
-        t.rows(species_id_results) do |taxon|
+        t.rows do |taxon|
           [
             taxon.species_id,
             markdown_taxon_link(taxon),

--- a/app/database_scripts/database_scripts/taxa_referencing_non_existing_taxa.rb
+++ b/app/database_scripts/database_scripts/taxa_referencing_non_existing_taxa.rb
@@ -33,3 +33,4 @@ description: >
   The columns included in this check are: `species_id` (other are OK).
 
 topic_areas: [catalog]
+issue_description: This subspecies belongs to a species that has been deleted, or does not exists for any other reason.

--- a/app/database_scripts/database_scripts/taxa_with_both_junior_and_senior_synonyms.rb
+++ b/app/database_scripts/database_scripts/taxa_with_both_junior_and_senior_synonyms.rb
@@ -9,3 +9,4 @@ end
 __END__
 description: See %github279.
 topic_areas: [synonyms]
+issue_description: This taxon has both senior and junior synonyms.

--- a/app/database_scripts/database_scripts/taxa_with_more_than_one_senior_synonym.rb
+++ b/app/database_scripts/database_scripts/taxa_with_more_than_one_senior_synonym.rb
@@ -29,3 +29,4 @@ description: >
   in synonyms section on the edit page, that may have to do with
   [Synonym records referencing non existent taxa](/database_scripts/synonym_records_referencing_non_existent_taxa).
 topic_areas: [synonyms]
+issue_description: This taxon has more than one senior synonyn.

--- a/app/database_scripts/database_scripts/taxa_with_more_than_one_senior_synonym.rb
+++ b/app/database_scripts/database_scripts/taxa_with_more_than_one_senior_synonym.rb
@@ -18,7 +18,7 @@ module DatabaseScripts
       def synonym_records_with_more_than_one_senior
         Synonym.group(:junior_synonym_id).
           having('COUNT(synonyms.senior_synonym_id) > 1').
-          pluck(:junior_synonym_id)
+          select(:junior_synonym_id)
       end
   end
 end

--- a/app/database_scripts/database_scripts/valid_taxa_listed_as_another_taxons_junior_synonym.rb
+++ b/app/database_scripts/database_scripts/valid_taxa_listed_as_another_taxons_junior_synonym.rb
@@ -10,3 +10,4 @@ __END__
 description: See %github279.
 tags: [regression-test]
 topic_areas: [synonyms]
+issue_description: This taxon has the status 'valid', but it also has senior synonym(s).

--- a/app/database_scripts/database_scripts/valid_taxa_listed_as_another_taxons_junior_synonym.rb
+++ b/app/database_scripts/database_scripts/valid_taxa_listed_as_another_taxons_junior_synonym.rb
@@ -1,7 +1,7 @@
 module DatabaseScripts
   class ValidTaxaListedAsAnotherTaxonsJuniorSynonym < DatabaseScript
     def results
-      Taxon.where(id: Synonym.pluck(:junior_synonym_id)).valid
+      Taxon.where(id: Synonym.select(:junior_synonym_id)).valid
     end
   end
 end

--- a/app/models/concerns/taxa/callbacks_and_validations.rb
+++ b/app/models/concerns/taxa/callbacks_and_validations.rb
@@ -6,6 +6,20 @@ module Taxa::CallbacksAndValidations
   BIOGEOGRAPHIC_REGIONS = %w[
     Nearctic Neotropic Palearctic Afrotropic Malagasy Indomalaya Australasia Oceania Antarctic
   ]
+  WARN_ON_DATABASE_SCRIPTS_RUNTIME_OVER = 0.1.seconds
+  DATABASE_SCRIPTS_TO_CHECK = [
+    DatabaseScripts::ExtantTaxaInFossilGenera,
+    DatabaseScripts::FossilTaxaWithBiogeographicRegions,
+    DatabaseScripts::JuniorSynonymsListedAsAnotherTaxonsSenior,
+    DatabaseScripts::NonHomonymsWithAHomonymReplacedById,
+    DatabaseScripts::PassThroughNamesWithTaxts,
+    DatabaseScripts::SubspeciesWithoutSpecies,
+    DatabaseScripts::TaxaAboveSpeciesWithBiogeographicRegions,
+    DatabaseScripts::TaxaReferencingNonExistingTaxa,
+    DatabaseScripts::TaxaWithBothJuniorAndSeniorSynonyms,
+    DatabaseScripts::TaxaWithMoreThanOneSeniorSynonym,
+    DatabaseScripts::ValidTaxaListedAsAnotherTaxonsJuniorSynonym
+  ]
 
   included do
     validates :name, presence: true
@@ -13,6 +27,10 @@ module Taxa::CallbacksAndValidations
     validates :status, inclusion: { in: Status::STATUSES }
     validates :biogeographic_region, inclusion: { in: BIOGEOGRAPHIC_REGIONS, allow_nil: true }
     validate :current_valid_taxon_validation, :ensure_correct_name_type
+
+    validation_scope :soft_validation_warnings do |scope|
+      scope.validate :check_if_in_database_scripts_results
+    end
 
     before_create :build_default_taxon_state
     before_save :set_name_caches
@@ -27,6 +45,11 @@ module Taxa::CallbacksAndValidations
       :genus_species_header_notes_taxt, :biogeographic_region], replace_newlines: true
 
     strip_attributes only: [:primary_type_information, :secondary_type_information, :type_notes]
+
+    # NOTE: Not private, see https://github.com/gtd/validation_scopes#dont-use-private-methods
+    def check_if_in_database_scripts_results
+      _check_if_in_database_scripts_results
+    end
   end
 
   # Recursively save children, presumably to trigger callbacks and create
@@ -91,5 +114,21 @@ module Taxa::CallbacksAndValidations
       return unless name_id_changed? # Make sure taxa already in this state can be saved.
       error_message = "Rank (`#{self.class}`) and name type (`#{name.class}`) must match."
       errors.add :base, error_message unless errors.added? :base, error_message
+    end
+
+    def _check_if_in_database_scripts_results
+      start = Time.current
+
+      DATABASE_SCRIPTS_TO_CHECK.each do |database_script_klass|
+        next unless database_script_klass.taxon_in_results?(self)
+
+        database_script = database_script_klass.new
+        soft_validation_warnings.add :base, message: database_script.issue_description, database_script: database_script
+      end
+
+      render_duration = Time.current - start
+      if render_duration > WARN_ON_DATABASE_SCRIPTS_RUNTIME_OVER
+        soft_validation_warnings.add :base, message: "Script runtime: #{render_duration} seconds"
+      end
     end
 end

--- a/app/models/database_script.rb
+++ b/app/models/database_script.rb
@@ -36,6 +36,10 @@ class DatabaseScript
     new.results.where(id: taxon.id).exists?
   end
 
+  def soft_validated?
+    self.class.in?(Taxa::CallbacksAndValidations::DATABASE_SCRIPTS_TO_CHECK)
+  end
+
   def description
     end_data[:description] || ""
   end

--- a/app/models/database_script.rb
+++ b/app/models/database_script.rb
@@ -26,10 +26,10 @@ class DatabaseScript
   end
 
   def self.all
-    Dir.glob("#{SCRIPTS_DIR}/*").sort.map do |path|
-      basename = File.basename path, ".rb"
-      new_from_filename_without_extension basename
-    end
+    @all ||= Dir.glob("#{SCRIPTS_DIR}/*").sort.map do |path|
+               basename = File.basename path, ".rb"
+               new_from_filename_without_extension basename
+             end
   end
 
   def description

--- a/app/models/database_script.rb
+++ b/app/models/database_script.rb
@@ -40,6 +40,10 @@ class DatabaseScript
     end_data[:description] || ""
   end
 
+  def issue_description
+    end_data[:issue_description]
+  end
+
   def tags
     end_data[:tags] || []
   end

--- a/app/models/database_script.rb
+++ b/app/models/database_script.rb
@@ -32,6 +32,10 @@ class DatabaseScript
              end
   end
 
+  def self.taxon_in_results? taxon
+    new.results.where(id: taxon.id).exists?
+  end
+
   def description
     end_data[:description] || ""
   end

--- a/app/views/application/_navigation.haml
+++ b/app/views/application/_navigation.haml
@@ -18,7 +18,8 @@
             %li=link_to "Editor's Panel", editors_panel_path, class: "top-header-link #{'very-active' if menu_active?(:editors_panel)}"
 
           -if user_signed_in?
-            %li=link_to 'Fix Random!', catalog_fix_random_path, class: "top-header-link"
+            -if AntCat::SHOW_SOFT_VALIDATION_WARNINGS_IN_CATALOG
+              %li=link_to 'Fix Random!', catalog_fix_random_path, class: "top-header-link"
             %li=link_to 'Changes', changes_path, class: "top-header-link #{'very-active' if menu_active?(:changes)}"
             %li=link_to current_user.name, current_user, class: "top-header-link"
             %li=link_to 'Logout', destroy_user_session_path, method: :delete, class: "top-header-link"

--- a/app/views/application/_navigation.haml
+++ b/app/views/application/_navigation.haml
@@ -18,6 +18,7 @@
             %li=link_to "Editor's Panel", editors_panel_path, class: "top-header-link #{'very-active' if menu_active?(:editors_panel)}"
 
           -if user_signed_in?
+            %li=link_to 'Fix Random!', catalog_fix_random_path, class: "top-header-link"
             %li=link_to 'Changes', changes_path, class: "top-header-link #{'very-active' if menu_active?(:changes)}"
             %li=link_to current_user.name, current_user, class: "top-header-link"
             %li=link_to 'Logout', destroy_user_session_path, method: :delete, class: "top-header-link"

--- a/app/views/catalog/show.haml
+++ b/app/views/catalog/show.haml
@@ -16,6 +16,16 @@
       -else
         =render "taxon_description", taxon: @taxon
   .medium-3.columns
+    -# Ignore "Issue" sidebar for Formicidae for performance and a cleaner look.
+    -unless @taxon.is_a?(Family)
+      -if current_user && @taxon.has_soft_validation_warnings?
+        #soft-validations.callout.warning
+          %h6
+            Issues
+            .right
+              =link_to 'Give me another!', catalog_fix_random_path, class: 'btn-tiny btn-normal'
+          =render 'shared/soft_validation_warnings', soft_validation_warnings: @taxon.soft_validation_warnings
+
     -unless @taxon.original_combination?
       -if show_full_statistics? @taxon
         -statistics = @taxon.decorate.statistics

--- a/app/views/catalog/show.haml
+++ b/app/views/catalog/show.haml
@@ -17,7 +17,7 @@
         =render "taxon_description", taxon: @taxon
   .medium-3.columns
     -# Ignore "Issue" sidebar for Formicidae for performance and a cleaner look.
-    -unless @taxon.is_a?(Family)
+    -if AntCat::SHOW_SOFT_VALIDATION_WARNINGS_IN_CATALOG && !@taxon.is_a?(Family)
       -if current_user && @taxon.has_soft_validation_warnings?
         #soft-validations.callout.warning
           %h6

--- a/app/views/database_scripts/index.haml
+++ b/app/views/database_scripts/index.haml
@@ -20,6 +20,8 @@
         =surround "(", ")" do
           =external_link_to "Regression testing", "https://en.wikipedia.org/wiki/Regression_testing"
       %p
+        "Soft-validated" scripts is where "Fix random!" taxa are randomized from
+      %p
         =DatabaseScript.decorate_class.format_tags [DatabaseScript::VERY_SLOW_TAG]
         may cause the site to become unresponsive
 
@@ -30,9 +32,13 @@
         %th.no-wrap Topic area
         %th Script
         %th.no-wrap Tags
+        %th Soft-validated
     %tbody
       -database_scripts.each do |database_script|
         %tr
           %td.shrink=database_script.decorate.format_topic_areas
           %td=link_to database_script.title, database_script_path(database_script)
           %td=database_script.decorate.format_tags
+          %td.shrink
+            -if database_script.soft_validated?
+              =antcat_icon("check")

--- a/app/views/shared/_soft_validation_warnings.haml
+++ b/app/views/shared/_soft_validation_warnings.haml
@@ -1,0 +1,7 @@
+%ul
+  -soft_validation_warnings.full_messages.each do |warning|
+    %li
+      =sanitize(warning[:message])
+      -database_script = warning[:database_script]
+      -if database_script
+        =link_to 'See more similiar.', database_script_path(database_script), title: database_script.title

--- a/app/views/taxa/_form.haml
+++ b/app/views/taxa/_form.haml
@@ -19,6 +19,15 @@
 
   =render 'shared/errors_for', resource: @taxon
 
+  -if @taxon.has_soft_validation_warnings?
+    #soft-validations.callout.warning.small-12.medium-6{data: { closable: true }}
+      %h6 Issues
+      %p These issues will not prevent you from saving the form. Just so you know :)
+      =render 'shared/soft_validation_warnings', soft_validation_warnings: @taxon.soft_validation_warnings
+
+      %button.close-button{"aria-label" => "Dismiss alert", data: { close: true }, type: "button"}
+        %span{"aria-hidden" => "true"} &times;
+
   .callout
     =render 'taxa/_form/main_form',        taxon: @taxon, form: form, default_name_string: @default_name_string
     =render 'taxa/_form/protonym_section', taxon: @taxon, form: form

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,10 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module AntCat
+  # TODO: Very primitive feature toggling.
+  # Added to make is easier to disable 'Fix Random!' in case of performance issues.
+  SHOW_SOFT_VALIDATION_WARNINGS_IN_CATALOG = true
+
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     # config.load_defaults 5.1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
     get :show_invalid
     get :show_valid_only
     get "random", to: "random#show"
+    get "fix_random", to: "fix_random#show"
     get "search", to: "search#index"
     get "search/quick_search", to: "search#quick_search", as: "quick_search"
   end

--- a/features/editors_panel/database_scripts.feature
+++ b/features/editors_panel/database_scripts.feature
@@ -10,6 +10,15 @@ Feature: Database scripts
     When I follow "Subspecies without species"
     Then I should see "Lasius specius subspecius"
 
+  Scenario: Displaying database script issues in catalog pages
+    Given there is a Lasius subspecies without a species
+
+    When I go to the catalog page for "Lasius specius subspecius"
+    Then I should see "This subspecies has no species"
+
+    When I follow "See more similiar."
+    Then I should see "Catalog: Subspecies without species"
+
   Scenario: Show tags, and description with markdown
     Then I should see "regression-test"
 

--- a/features/editors_panel/database_scripts.feature
+++ b/features/editors_panel/database_scripts.feature
@@ -11,7 +11,8 @@ Feature: Database scripts
     Then I should see "Lasius specius subspecius"
 
   Scenario: Displaying database script issues in catalog pages
-    Given there is a Lasius subspecies without a species
+    Given SHOW_SOFT_VALIDATION_WARNINGS_IN_CATALOG is true
+    And there is a Lasius subspecies without a species
 
     When I go to the catalog page for "Lasius specius subspecius"
     Then I should see "This subspecies has no species"

--- a/features/step_definitions/database_scripts_steps.rb
+++ b/features/step_definitions/database_scripts_steps.rb
@@ -1,3 +1,7 @@
+Given("SHOW_SOFT_VALIDATION_WARNINGS_IN_CATALOG is true") do
+  stub_const "AntCat::SHOW_SOFT_VALIDATION_WARNINGS_IN_CATALOG", true
+end
+
 Given("there is a Lasius subspecies without a species") do
   subspecies = create_subspecies "Lasius specius subspecius", species: nil
   expect(subspecies.species).to be nil

--- a/spec/models/database_script_spec.rb
+++ b/spec/models/database_script_spec.rb
@@ -42,6 +42,19 @@ describe DatabaseScript do
     end
   end
 
+  describe '.taxon_in_results?' do
+    context "when taxon is in the script's results" do
+      let(:script) { DatabaseScripts::ExtantTaxaInFossilGenera }
+      let(:extant_species) { create :species }
+
+      specify do
+        expect { extant_species.genus.update! fossil: true }.
+          to change { script.taxon_in_results?(extant_species) }.
+          from(false).to(true)
+      end
+    end
+  end
+
   describe "testsing with a real script" do
     let(:script) { DatabaseScripts::ValidTaxaListedAsAnotherTaxonsJuniorSynonym.new }
 

--- a/spec/models/database_script_spec.rb
+++ b/spec/models/database_script_spec.rb
@@ -75,6 +75,12 @@ describe DatabaseScript do
       end
     end
 
+    describe "#issue_description" do
+      it "can have a description" do
+        expect(script.issue_description).to match "This taxon has the status 'valid', but it also has senior synonym(s)."
+      end
+    end
+
     describe "#tags" do
       it "can have tags" do
         expect(script.tags).to eq ["regression-test"]

--- a/spec/models/database_script_spec.rb
+++ b/spec/models/database_script_spec.rb
@@ -55,6 +55,13 @@ describe DatabaseScript do
     end
   end
 
+  describe '#soft_validated?' do
+    it 'returns true if the script is used for taxon soft-validations' do
+      expect(Taxa::CallbacksAndValidations::DATABASE_SCRIPTS_TO_CHECK.first.new.soft_validated?).to eq true
+      expect(DatabaseScripts::ValidSpeciesList.new.soft_validated?).to eq false
+    end
+  end
+
   describe "testsing with a real script" do
     let(:script) { DatabaseScripts::ValidTaxaListedAsAnotherTaxonsJuniorSynonym.new }
 


### PR DESCRIPTION
Experimental soft-validation warnings: They are shown in the taxon form, and in catalog pages (only logged in users). The 'Fix Random!' link randomizes a catalog page that has issues to fix. The idea is to make editors aware of issues. The validations are from database scripts.

![fix_random](https://user-images.githubusercontent.com/1513381/54712115-cc13f080-4b4b-11e9-91b9-26731c51e518.png)
