### PR TITLE
remove: taxon.genus_species_header_notes_taxt

### DIFF
--- a/app/database_scripts/database_scripts/epi_and_questionmark_taxt_tags.rb
+++ b/app/database_scripts/database_scripts/epi_and_questionmark_taxt_tags.rb
@@ -58,7 +58,7 @@ description: >
 
 
   Click on the links to see where they are used. If `Item type` says `Taxon`, the taxt tag is contained
-   in either `headline_notes_taxt`, `type_taxt` or `genus_species_header_notes_taxt` of that taxon.
+   in either `headline_notes_taxt` or `type_taxt` of that taxon.
   If it says `Citation`, the taxt is stored in the `notes_taxt` column of that citation;
   since it's not possible no link citations, the taxon which's protonym references that citation.
 topic_areas: [taxt]

--- a/app/database_scripts/database_scripts/nam_taxt_tags.rb
+++ b/app/database_scripts/database_scripts/nam_taxt_tags.rb
@@ -55,7 +55,7 @@ description: >
 
 
   Click on the links to see where they are used. If `Item type` says `Taxon`, the taxt tag is contained
-   in either `headline_notes_taxt`, `type_taxt` or `genus_species_header_notes_taxt` of that taxon.
+   in either `headline_notes_taxt` or `type_taxt` of that taxon.
   If it says `Citation`, the taxt is stored in the `notes_taxt` column of that citation;
   since it's not possible no link citations, the taxon which's protonym references that citation.
 topic_areas: [taxt]

--- a/app/models/concerns/taxa/callbacks_and_validations.rb
+++ b/app/models/concerns/taxa/callbacks_and_validations.rb
@@ -41,7 +41,7 @@ module Taxa::CallbacksAndValidations
     before_save { save_children if save_initiator }
 
     strip_attributes only: [:incertae_sedis_in, :type_taxt, :headline_notes_taxt,
-      :genus_species_header_notes_taxt, :biogeographic_region], replace_newlines: true
+      :biogeographic_region], replace_newlines: true
 
     strip_attributes only: [:primary_type_information, :secondary_type_information, :type_notes]
 

--- a/app/services/exporters/antweb/export_taxon.rb
+++ b/app/services/exporters/antweb/export_taxon.rb
@@ -126,16 +126,10 @@ class Exporters::Antweb::ExportTaxon
       content_tag :div, class: 'antcat_taxon' do # NOTE `.antcat_taxon` is used on AntWeb.
         content = ''.html_safe
         content << taxon.statistics(valid_only: true)
-        content << genus_species_header_notes_taxt(taxon)
         content << Exporters::Antweb::ExportHeadline[taxon]
         content << Exporters::Antweb::ExportHistoryItems[taxon]
         content << taxon.child_lists(for_antweb: true)
         content << Exporters::Antweb::ExportReferenceSections[taxon]
       end
-    end
-
-    def genus_species_header_notes_taxt taxon
-      return if taxon.genus_species_header_notes_taxt.blank?
-      content_tag :div, TaxtPresenter[taxon.genus_species_header_notes_taxt].to_antweb
     end
 end

--- a/app/services/taxa/copy_attributes.rb
+++ b/app/services/taxa/copy_attributes.rb
@@ -41,7 +41,6 @@ module Taxa
           :type_taxt,
           :headline_notes_taxt,
           :hong,
-          :genus_species_header_notes_taxt,
           :unresolved_homonym,
           :current_valid_taxon_id,
           :ichnotaxon,

--- a/app/views/catalog/_taxon_description.haml
+++ b/app/views/catalog/_taxon_description.haml
@@ -4,8 +4,6 @@
   =taxon.decorate.taxon_status
   =taxon.name.gender
 
-=TaxtPresenter[taxon.genus_species_header_notes_taxt].to_html
-
 .headline
   %span.name
     =link_to taxon.protonym.decorate.format_name, taxon.protonym

--- a/lib/taxt.rb
+++ b/lib/taxt.rb
@@ -11,7 +11,6 @@ class Taxt
       TaxonHistoryItem => ['taxt'],
       Taxon            => ['headline_notes_taxt',
                            'type_taxt',
-                           'genus_species_header_notes_taxt',
                            'primary_type_information',
                            'secondary_type_information',
                            'type_notes'],

--- a/public/api/v1/swagger.yaml
+++ b/public/api/v1/swagger.yaml
@@ -716,8 +716,6 @@ definitions:
             type: string
           type_taxon_id:
             type: integer
-          genus_species_header_notes_taxt:
-            type: string
           name_cache:
             type: string
             description: de-normalized cache of the name object

--- a/spec/services/names/what_links_here_spec.rb
+++ b/spec/services/names/what_links_here_spec.rb
@@ -54,7 +54,7 @@ describe Names::WhatLinksHere do
 
   def taxt_fields
     [
-      [Taxon, [:type_taxt, :headline_notes_taxt, :genus_species_header_notes_taxt]],
+      [Taxon, [:type_taxt, :headline_notes_taxt]],
       [Citation, [:notes_taxt]],
       [ReferenceSection, [:title_taxt, :subtitle_taxt, :references_taxt]],
       [TaxonHistoryItem, [:taxt]]

--- a/spec/services/references/what_links_here_spec.rb
+++ b/spec/services/references/what_links_here_spec.rb
@@ -10,8 +10,7 @@ describe References::WhatLinksHere do
       taxon = create :genus,
         protonym: protonym,
         type_taxt: "{ref #{reference.id}}",
-        headline_notes_taxt: "{ref #{reference.id}}",
-        genus_species_header_notes_taxt: "{ref #{reference.id}}"
+        headline_notes_taxt: "{ref #{reference.id}}"
       history_item = taxon.history_items.create! taxt: "{ref #{reference.id}}"
       reference_section = create :reference_section,
         title_taxt: "{ref #{reference.id}}",
@@ -23,7 +22,6 @@ describe References::WhatLinksHere do
       expect(results).to match_array [
         { table: 'taxa',                id: taxon.id,             field: :type_taxt },
         { table: 'taxa',                id: taxon.id,             field: :headline_notes_taxt },
-        { table: 'taxa',                id: taxon.id,             field: :genus_species_header_notes_taxt },
         { table: 'citations',           id: citation.id,          field: :notes_taxt },
         { table: 'citations',           id: citation.id,          field: :reference_id },
         { table: 'reference_sections',  id: reference_section.id, field: :title_taxt },

--- a/spec/services/taxa/convert_to_subspecies_spec.rb
+++ b/spec/services/taxa/convert_to_subspecies_spec.rb
@@ -71,7 +71,6 @@ describe Taxa::ConvertToSubspecies do
             :type_taxt,
             :headline_notes_taxt,
             :hong,
-            :genus_species_header_notes_taxt,
             :unresolved_homonym,
             :current_valid_taxon,
             :ichnotaxon,

--- a/spec/services/taxa/copy_attributes_spec.rb
+++ b/spec/services/taxa/copy_attributes_spec.rb
@@ -14,7 +14,6 @@ describe Taxa::CopyAttributes do
         "type_taxt" => taxon.type_taxt,
         "headline_notes_taxt" => taxon.headline_notes_taxt,
         "hong" => taxon.hong,
-        "genus_species_header_notes_taxt" => taxon.genus_species_header_notes_taxt,
         "unresolved_homonym" => taxon.unresolved_homonym,
         "current_valid_taxon_id" => taxon.current_valid_taxon_id,
         "ichnotaxon" => taxon.ichnotaxon,

--- a/spec/services/taxa/elevate_to_species_spec.rb
+++ b/spec/services/taxa/elevate_to_species_spec.rb
@@ -66,7 +66,6 @@ describe Taxa::ElevateToSpecies do
             :type_taxt,
             :headline_notes_taxt,
             :hong,
-            :genus_species_header_notes_taxt,
             :unresolved_homonym,
             :current_valid_taxon,
             :ichnotaxon,


### PR DESCRIPTION
See https://github.com/calacademy-research/antcat/issues/512

It was only being used for six taxa (which has been migrated) and it could not be changed in the GUI.