### PR TITLE
Remove unused taxon type columns

### DIFF
--- a/db/migrate/20171022020010_add_type_fields_to_taxa.rb
+++ b/db/migrate/20171022020010_add_type_fields_to_taxa.rb
@@ -1,11 +1,3 @@
-# TODO remove:
-# ```
-# :verbatim_type_locality,
-# :type_specimen_repository,
-# :type_specimen_code,
-# :type_specimen_url
-# ```
-
 class AddTypeFieldsToTaxa < ActiveRecord::Migration
   def change
     add_column :taxa, :published_type_information, :text, nil: true

--- a/db/migrate/20190108035206_add_type_taxon_id_to_taxa.rb
+++ b/db/migrate/20190108035206_add_type_taxon_id_to_taxa.rb
@@ -1,6 +1,3 @@
-# TODO remove column `taxa.type_name_id`.
-# TODO remove column `taxa.type_fossil`.
-
 class AddTypeTaxonIdToTaxa < ActiveRecord::Migration[5.1]
   def change
     add_column :taxa, :type_taxon_id, :integer

--- a/db/migrate/20190402204649_remove_unused_type_columns_from_taxa.rb
+++ b/db/migrate/20190402204649_remove_unused_type_columns_from_taxa.rb
@@ -1,0 +1,10 @@
+class RemoveUnusedTypeColumnsFromTaxa < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :taxa, :type_name_id, :integer
+    remove_column :taxa, :type_fossil, :boolean
+    remove_column :taxa, :verbatim_type_locality, :text
+    remove_column :taxa, :type_specimen_repository, :text
+    remove_column :taxa, :type_specimen_code, :text
+    remove_column :taxa, :type_specimen_url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_31_150031) do
+ActiveRecord::Schema.define(version: 2019_04_02_204649) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "trackable_id"
@@ -356,8 +356,6 @@ ActiveRecord::Schema.define(version: 2019_03_31_150031) do
     t.integer "subgenus_id"
     t.boolean "hong", default: false, null: false
     t.integer "name_id"
-    t.integer "type_name_id"
-    t.boolean "type_fossil"
     t.string "name_cache"
     t.string "name_html_cache"
     t.boolean "unresolved_homonym", default: false, null: false
@@ -365,11 +363,7 @@ ActiveRecord::Schema.define(version: 2019_03_31_150031) do
     t.boolean "ichnotaxon"
     t.boolean "nomen_nudum"
     t.integer "family_id"
-    t.text "verbatim_type_locality"
     t.string "biogeographic_region"
-    t.text "type_specimen_repository"
-    t.text "type_specimen_code"
-    t.text "type_specimen_url"
     t.boolean "auto_generated", default: false
     t.string "origin"
     t.integer "hol_id"
@@ -391,7 +385,6 @@ ActiveRecord::Schema.define(version: 2019_03_31_150031) do
     t.index ["subgenus_id"], name: "index_taxa_on_subgenus_id"
     t.index ["tribe_id"], name: "taxa_tribe_id_idx"
     t.index ["type"], name: "taxa_type_idx"
-    t.index ["type_name_id"], name: "index_taxa_on_type_name_id"
     t.index ["type_taxon_id"], name: "fk_taxa__type_taxon_id__taxa__id"
   end
 


### PR DESCRIPTION
See #461

Columns:

* `taxa.type_name_id`
* `taxa.type_fossil`
* `taxa.verbatim_type_locality`
* `taxa.type_specimen_repository`
* `taxa.type_specimen_code`
* `taxa.type_specimen_url`