### PR TITLE
Dynamic HTML names - part 1

### DIFF
--- a/app/controllers/taxa/convert_to_subspecies_controller.rb
+++ b/app/controllers/taxa/convert_to_subspecies_controller.rb
@@ -77,7 +77,7 @@ module Taxa
           parameters: {
             original_species_id: original_species.id,
             name_was: original_species.name_html_cache,
-            name: new_subspecies.name.name_html
+            name: new_subspecies.name.name_to_html
           }
       end
   end

--- a/app/controllers/taxa/elevate_to_species_controller.rb
+++ b/app/controllers/taxa/elevate_to_species_controller.rb
@@ -41,7 +41,7 @@ module Taxa
           parameters: {
             original_subspecies_id: subspecies.id,
             name_was: subspecies.name_html_cache,
-            name: new_species.name.name_html
+            name: new_species.name.name_to_html
           }
       end
   end

--- a/app/decorators/taxon_decorator/link_each_epithet.rb
+++ b/app/decorators/taxon_decorator/link_each_epithet.rb
@@ -14,12 +14,12 @@ class TaxonDecorator::LinkEachEpithet
     string = genus_link @taxon
 
     if @taxon.is_a? Species
-      return string << header_link(@taxon, @taxon.name.epithet_html.html_safe)
+      return string << header_link(@taxon, @taxon.name.epithet_to_html.html_safe)
     end
 
     species = @taxon.species
     if species
-      string << header_link(species, species.name.epithet_html.html_safe)
+      string << header_link(species, species.name.epithet_to_html.html_safe)
       string << ' '.html_safe
       string << header_link(@taxon, italicize(@taxon.name.subspecies_epithets))
     else

--- a/app/helpers/taxon_select_helper.rb
+++ b/app/helpers/taxon_select_helper.rb
@@ -13,7 +13,7 @@ module TaxonSelectHelper
     def taxon_data_attributes taxon, rank
       for_taxon = if taxon
                     {
-                      name_html: taxon.name.name_html,
+                      name_html: taxon.name.name_to_html,
                       name_with_fossil: taxon.name_with_fossil,
                       author_citation: taxon.author_citation
                     }

--- a/app/models/concerns/taxa/callbacks_and_validations.rb
+++ b/app/models/concerns/taxa/callbacks_and_validations.rb
@@ -62,7 +62,7 @@ module Taxa::CallbacksAndValidations
 
     def set_name_caches
       self.name_cache = name.name
-      self.name_html_cache = name.name_html
+      self.name_html_cache = name.name_to_html
     end
 
     def delete_synonyms

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -20,12 +20,16 @@ class Name < ApplicationRecord
     self.class.name.gsub(/Name$/, "").underscore
   end
 
+  def epithet_to_html
+    epithet
+  end
+
   def to_html_with_fossil fossil
     "#{dagger_html if fossil}#{name_html}".html_safe
   end
 
   def epithet_with_fossil_html fossil
-    "#{dagger_html if fossil}#{epithet_html}".html_safe
+    "#{dagger_html if fossil}#{epithet_to_html}".html_safe
   end
 
   def dagger_html

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -20,12 +20,16 @@ class Name < ApplicationRecord
     self.class.name.gsub(/Name$/, "").underscore
   end
 
+  def name_to_html
+    name
+  end
+
   def epithet_to_html
     epithet
   end
 
   def to_html_with_fossil fossil
-    "#{dagger_html if fossil}#{name_html}".html_safe
+    "#{dagger_html if fossil}#{name_to_html}".html_safe
   end
 
   def epithet_with_fossil_html fossil
@@ -47,6 +51,6 @@ class Name < ApplicationRecord
     end
 
     def set_taxon_caches
-      Taxon.where(name: self).update_all(name_cache: name, name_html_cache: name_html)
+      Taxon.where(name: self).update_all(name_cache: name, name_html_cache: name_to_html)
     end
 end

--- a/app/models/names/genus_group_name.rb
+++ b/app/models/names/genus_group_name.rb
@@ -1,4 +1,8 @@
 class GenusGroupName < Name
+  def epithet_to_html
+    italicize epithet
+  end
+
   def dagger_html
     italicize super
   end

--- a/app/models/names/genus_group_name.rb
+++ b/app/models/names/genus_group_name.rb
@@ -1,4 +1,8 @@
 class GenusGroupName < Name
+  def name_to_html
+    italicize name
+  end
+
   def epithet_to_html
     italicize epithet
   end

--- a/app/models/names/species_group_name.rb
+++ b/app/models/names/species_group_name.rb
@@ -1,4 +1,8 @@
 class SpeciesGroupName < Name
+  def name_to_html
+    italicize name
+  end
+
   def epithet_to_html
     italicize epithet
   end

--- a/app/models/names/species_group_name.rb
+++ b/app/models/names/species_group_name.rb
@@ -1,4 +1,8 @@
 class SpeciesGroupName < Name
+  def epithet_to_html
+    italicize epithet
+  end
+
   def genus_epithet
     words[0]
   end

--- a/app/services/names/picklist_matching.rb
+++ b/app/services/names/picklist_matching.rb
@@ -1,5 +1,3 @@
-# TODO refactor more.
-
 class Names::PicklistMatching
   include Service
 
@@ -34,14 +32,14 @@ class Names::PicklistMatching
     end
 
     def picklist_query name_field, search_term
-      Name.select('names.id AS id, name, name_html, taxa.id AS taxon_id').
+      Name.select('names.id AS id, name, taxa.id AS taxon_id').
         joins("LEFT OUTER JOIN taxa ON taxa.name_id = names.id").
         where("#{name_field} LIKE ?", search_term)
     end
 
     def format matches
       matches.map do |e|
-        result = { id: e.id.to_i, name: e.name, label: e.name_html, value: e.name }
+        result = { id: e.id.to_i, name: e.name, label: e.name, value: e.name }
         result[:taxon_id] = e.taxon_id.to_i if e.taxon_id
         result
       end

--- a/app/views/taxa/create_obsolete_combinations/show.haml
+++ b/app/views/taxa/create_obsolete_combinations/show.haml
@@ -35,7 +35,7 @@
           This page is for creating missing obsolete combination records. A new record will be created when "Create" is pressed. The new record will have:
           %ul
             %li its genus set to the obsolete genus
-            %li the name will be: obsolete genus name + #{@taxon.name.epithet_html.html_safe}
+            %li the name will be: obsolete genus name + #{@taxon.name.epithet_to_html.html_safe}
             %li its current valid name set to #{@taxon.name_with_fossil}
             %li
               the status set to

--- a/db/migrate/20150805233239_remove_nonstandard_notation.rb
+++ b/db/migrate/20150805233239_remove_nonstandard_notation.rb
@@ -41,14 +41,13 @@ class RemoveNonstandardNotation < ActiveRecord::Migration
         name.origin = 'migration remove_nonstandard_notation'
         name.save
       end
-      puts "  name_html: '#{name.name_html}' name id: '#{name.id}' name: '#{name.name}'"
 
       new_taxon = mother.create_taxon Rank[taxon.rank], taxon.parent
       new_taxon.auto_generated = true
       new_taxon.origin = 'migration'
       new_taxon.status = "unavailable uncategorized"
       new_taxon.current_valid_taxon_id = current_valid_taxon.id
-      new_taxon.name_html_cache = name.name_html
+      new_taxon.name_html_cache = name.name_to_html
       new_taxon.name_cache = name.name
       new_taxon.name_id = name.id
       new_taxon.protonym_id = taxon.protonym_id

--- a/db/migrate/20150811165357_remove_protonym_html.rb
+++ b/db/migrate/20150811165357_remove_protonym_html.rb
@@ -54,7 +54,6 @@ class RemoveProtonymHtml < ActiveRecord::Migration
       new_name_record.origin = 'migration'
       new_name_record.nonconforming_name = name.nonconforming_name
       new_name_record.save
-      puts "  Made new name: #{new_name_record.id} with name #{new_name_record.name} and html: #{new_name_record.name_html}"
     end
 
     # Find all references to the old name id, and replace it with the new name id.

--- a/public/api/v1/swagger.yaml
+++ b/public/api/v1/swagger.yaml
@@ -827,15 +827,9 @@ definitions:
       name:
         type: string
         description: Plain text name
-      name_html:
-        type: string
-        description: html version of name (with formatting, usually italics)
       epithet:
         type: string
         description: Plain text terminal epithet
-      epithet_html:
-        type: string
-        description: html version of terminal epithet (with formatting, usually italics)
       epithets:
         type: string
         description: all epithets, plain text

--- a/spec/decorators/table_ref_decorator_spec.rb
+++ b/spec/decorators/table_ref_decorator_spec.rb
@@ -32,7 +32,7 @@ describe TableRefDecorator do
     let!(:name) { object.name }
 
     specify { expect(decorated.item_link).to eq %(<a href="/protonyms/#{id}">#{id}</a>) }
-    specify { expect(decorated.related_links).to eq %(<a href="/protonyms/#{id}">Protonym: #{name.name_html}</a>) }
+    specify { expect(decorated.related_links).to eq %(<a href="/protonyms/#{id}">Protonym: #{name.name_to_html}</a>) }
   end
 
   context "when table is `reference_sections`" do

--- a/spec/models/name_spec.rb
+++ b/spec/models/name_spec.rb
@@ -6,12 +6,12 @@ describe Name do
 
   describe "#epithet_with_fossil_html" do
     it "formats the fossil symbol" do
-      expect(SpeciesName.new(epithet_html: '<i>major</i>').epithet_with_fossil_html(true)).to eq '<i>&dagger;</i><i>major</i>'
-      expect(SpeciesName.new(epithet_html: '<i>major</i>').epithet_with_fossil_html(false)).to eq '<i>major</i>'
-      expect(GenusName.new(epithet_html: '<i>Atta</i>').epithet_with_fossil_html(true)).to eq '<i>&dagger;</i><i>Atta</i>'
-      expect(GenusName.new(epithet_html: '<i>Atta</i>').epithet_with_fossil_html(false)).to eq '<i>Atta</i>'
-      expect(SubfamilyName.new(epithet_html: 'Attanae').epithet_with_fossil_html(true)).to eq '&dagger;Attanae'
-      expect(SubfamilyName.new(epithet_html: 'Attanae').epithet_with_fossil_html(false)).to eq 'Attanae'
+      expect(SpeciesName.new(epithet: 'major', epithet_html: '<i>major</i>').epithet_with_fossil_html(true)).to eq '<i>&dagger;</i><i>major</i>'
+      expect(SpeciesName.new(epithet: 'major', epithet_html: '<i>major</i>').epithet_with_fossil_html(false)).to eq '<i>major</i>'
+      expect(GenusName.new(epithet: 'Atta', epithet_html: '<i>Atta</i>').epithet_with_fossil_html(true)).to eq '<i>&dagger;</i><i>Atta</i>'
+      expect(GenusName.new(epithet: 'Atta', epithet_html: '<i>Atta</i>').epithet_with_fossil_html(false)).to eq '<i>Atta</i>'
+      expect(SubfamilyName.new(epithet: 'Attanae', epithet_html: 'Attanae').epithet_with_fossil_html(true)).to eq '&dagger;Attanae'
+      expect(SubfamilyName.new(epithet: 'Attanae', epithet_html: 'Attanae').epithet_with_fossil_html(false)).to eq 'Attanae'
     end
   end
 

--- a/spec/models/name_spec.rb
+++ b/spec/models/name_spec.rb
@@ -17,8 +17,8 @@ describe Name do
 
   describe "#to_html_with_fossil" do
     it "formats the fossil symbol" do
-      expect(SpeciesName.new(name_html: '<i>Atta major</i>').to_html_with_fossil(false)).to eq '<i>Atta major</i>'
-      expect(SpeciesName.new(name_html: '<i>Atta major</i>').to_html_with_fossil(true)).to eq '<i>&dagger;</i><i>Atta major</i>'
+      expect(SpeciesName.new(name: 'Atta major', name_html: '<i>Atta major</i>').to_html_with_fossil(false)).to eq '<i>Atta major</i>'
+      expect(SpeciesName.new(name: 'Atta major', name_html: '<i>Atta major</i>').to_html_with_fossil(true)).to eq '<i>&dagger;</i><i>Atta major</i>'
     end
   end
 

--- a/spec/models/taxa/species_group/subspecies_spec.rb
+++ b/spec/models/taxa/species_group/subspecies_spec.rb
@@ -52,6 +52,7 @@ describe Subspecies do
 
         expect(subspecies.name.name).to eq 'Eciton nigrus medius minor'
         expect(subspecies.name.name_html).to eq '<i>Eciton nigrus medius minor</i>'
+        expect(subspecies.name.name_to_html).to eq '<i>Eciton nigrus medius minor</i>'
         expect(subspecies.name.epithet).to eq 'minor'
         expect(subspecies.name.epithet_html).to eq '<i>minor</i>'
         expect(subspecies.name.epithets).to eq 'nigrus medius minor'

--- a/spec/services/names/create_name_from_string_spec.rb
+++ b/spec/services/names/create_name_from_string_spec.rb
@@ -9,6 +9,7 @@ describe Names::CreateNameFromString do
         expect(name).to be_a SubgenusName
         expect(name.name).to eq 'Camponotus (Forelophilus)'
         expect(name.name_html).to eq '<i>Camponotus (Forelophilus)</i>'
+        expect(name.name_to_html).to eq '<i>Camponotus (Forelophilus)</i>'
         expect(name.epithet).to eq 'Forelophilus'
         expect(name.epithet_html).to eq '<i>Forelophilus</i>'
       end

--- a/spec/services/names/picklist_matching_spec.rb
+++ b/spec/services/names/picklist_matching_spec.rb
@@ -1,5 +1,3 @@
-# TODO update after extracting from `Name`.
-
 require 'spec_helper'
 
 describe Names::PicklistMatching do
@@ -13,7 +11,7 @@ describe Names::PicklistMatching do
 
       expect(described_class['att']).to eq [
         id: name.id, name: name.name,
-        label: '<i>Atta</i>', value: name.name
+        label: 'Atta', value: name.name
       ]
     end
 
@@ -22,7 +20,7 @@ describe Names::PicklistMatching do
 
       expect(described_class['gyx']).to eq [
         id: name.id, name: name.name,
-        label: '<i>Gesomyrmex</i>', value: name.name
+        label: 'Gesomyrmex', value: name.name
       ]
     end
 
@@ -34,13 +32,13 @@ describe Names::PicklistMatching do
         {
           id: bothroponera.id,
           name: bothroponera.name,
-          label: '<i>Bothroponera</i>',
+          label: 'Bothroponera',
           value: bothroponera.name
         },
         {
           id: brachyponera.name.id,
           name: brachyponera.name.name,
-          label: '<i>Brachyponera</i>',
+          label: 'Brachyponera',
           taxon_id: brachyponera.id,
           value: brachyponera.name.name
         }
@@ -56,19 +54,19 @@ describe Names::PicklistMatching do
         {
           id: atta.id,
           name: 'Atta',
-          label: '<i>Atta</i>',
+          label: 'Atta',
           value: atta.name
         },
         {
           id: acanthognathus.id,
           name: 'Acanthognathus laevigatus',
-          label: '<i>Acanthognathus laevigatus</i>',
+          label: 'Acanthognathus laevigatus',
           value: acanthognathus.name
         },
         {
           id: acropyga.id,
           name: 'Acropyga dubitata',
-          label: '<i>Acropyga dubitata</i>',
+          label: 'Acropyga dubitata',
           value: acropyga.name
         }
       ]

--- a/spec/services/taxa/create_obsolete_combination_spec.rb
+++ b/spec/services/taxa/create_obsolete_combination_spec.rb
@@ -49,6 +49,7 @@ describe Taxa::CreateObsoleteCombination do
 
           expect(obsolete_combination.name.name).to eq new_name
           expect(obsolete_combination.name.name_html).to eq "<i>#{new_name}</i>"
+          expect(obsolete_combination.name.name_to_html).to eq "<i>#{new_name}</i>"
           expect(obsolete_combination.name.epithet).to eq current_valid_taxon_species_epithet
           expect(obsolete_combination.name.epithet_html).to eq "<i>#{current_valid_taxon_species_epithet}</i>"
         end


### PR DESCRIPTION
Meta issue: #604

Changes `Name#name_html` (attribute, now unused) -->  `Name#name_to_html` (method)

Any other reference that includes the word `name_html` are left as is. The plan is to drop `names.name_html` and rename the method to `#name_html`. Same thing with `Name#epithet_html`.

This will make creating names easier.