### PR TITLE
Check name conflicts in name form

### DIFF
--- a/app/assets/javascripts/check_name_conflicts.coffee
+++ b/app/assets/javascripts/check_name_conflicts.coffee
@@ -1,0 +1,70 @@
+DELAY_MS = 500
+
+# For the taxon form.
+TAXON_NAME_STRING = '#taxon_name_string'
+PROTONYM_NAME_STRING = '#protonym_name_string'
+COPY_NAME_TO_PROTONYM = '#copy-name-to-protonym-js-hook'
+
+# For the name form.
+NAME_NAME_STRING = '#name_name_string'
+
+$ ->
+  checkNameConflicts = (nameStringSelector, exceptNameId, numberOfWords) =>
+    $.ajax
+      url: "/names/check_name_conflicts"
+      type: "get"
+      data:
+        qq: $(nameStringSelector).val()
+        number_of_words: numberOfWords
+        except_name_id: exceptNameId
+      dataType: "json"
+      success: (names) =>
+        currentValue = $(nameStringSelector).val()
+        formattedNames = names.map (name) ->
+          warnAboutHomonym = name.name.toLowerCase() == $.trim(currentValue.toLowerCase())
+          homonymWarning = '<span class="bold-warning">Homonym</span> '
+
+          url = if name.taxon_id
+                   "/catalog/#{name.taxon_id}"
+                 else
+                   "/protonyms/#{name.protonym_id}"
+
+          string = ""
+          string += homonymWarning if warnAboutHomonym
+          string += "<a href='#{url}'>#{name.name_html}</a> "
+          string += ' (protonym)' unless name.taxon_id
+          string += " <small class='gray'>##{name.id}</small>"
+
+          "<li>#{string}</li>"
+
+        html = if formattedNames.length > 0
+                "<h6>Similar names</h3> #{formattedNames.join('')}"
+               else
+                 "<h6>Found no similar names <span class='antcat_icon check'></span></h3>"
+
+         $("#{nameStringSelector}-possible-conflicts-js-hook").html html
+
+      error: -> $.notify "Error checking for name conflicts"
+
+  $(TAXON_NAME_STRING).keyup ->
+    numberOfWords = $(TAXON_NAME_STRING).data('number-of-words')
+    AntCat.delay(checkNameConflicts, TAXON_NAME_STRING, null, numberOfWords)
+
+  $(PROTONYM_NAME_STRING).keyup -> AntCat.delay(checkNameConflicts, PROTONYM_NAME_STRING)
+
+  $(NAME_NAME_STRING).keyup ->
+    exceptNameId = $(NAME_NAME_STRING).data('name-id')
+    AntCat.delay(checkNameConflicts, NAME_NAME_STRING, exceptNameId)
+
+  $(COPY_NAME_TO_PROTONYM).click (event) ->
+    event.preventDefault()
+    taxon_name_string = $(TAXON_NAME_STRING).val()
+    $(PROTONYM_NAME_STRING).val taxon_name_string
+    $(PROTONYM_NAME_STRING).trigger('keyup')
+
+AntCat.delay = do ->
+  timer = 0
+  (callback, args...) ->
+    clearTimeout(timer)
+    cb = -> callback.apply(null, args)
+    timer = setTimeout(cb, DELAY_MS)

--- a/app/assets/stylesheets/widgets/_check_name_conflicts.sass
+++ b/app/assets/stylesheets/widgets/_check_name_conflicts.sass
@@ -1,0 +1,4 @@
+.possible-name-conflicts
+  max-height: 10rem
+  overflow-y: scroll
+  overflow-x: auto

--- a/app/controllers/names/check_name_conflicts_controller.rb
+++ b/app/controllers/names/check_name_conflicts_controller.rb
@@ -1,0 +1,29 @@
+module Names
+  class CheckNameConflictsController < ApplicationController
+    def show
+      if params[:qq].blank?
+        render json: []
+      else
+        render json: json_names, root: false
+      end
+    end
+
+    private
+
+      def names
+        Names::FindConflicts[params[:qq], params[:number_of_words], params[:except_name_id]]
+      end
+
+      def json_names
+        names.map do |n|
+          {
+            id: n.id,
+            name: n.name,
+            name_html: n.name_html,
+            taxon_id: n[:taxon_id],
+            protonym_id: n[:protonym_id]
+          }
+        end
+      end
+  end
+end

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -28,6 +28,7 @@ class Name < ApplicationRecord
   after_save :set_taxon_caches
 
   scope :single_word_names, -> { where(type: SINGLE_WORD_NAMES) }
+  scope :no_single_word_names, -> { where.not(type: SINGLE_WORD_NAMES) }
 
   has_paper_trail meta: { change_id: proc { UndoTracker.get_current_change_id } }
   strip_attributes replace_newlines: true

--- a/app/services/names/find_conflicts.rb
+++ b/app/services/names/find_conflicts.rb
@@ -1,0 +1,43 @@
+module Names
+  class FindConflicts
+    include Service
+
+    NUM_ITEMS = 30
+
+    SINGLE_WORD_NAMES_ONLY = 'single_word_names'
+    NO_SINGLE_WORD_NAMES = 'no_single_word_names'
+
+    def initialize search_query, number_of_words, except_name_id
+      @search_query = search_query
+      @number_of_words = number_of_words.presence
+      @except_name_id = except_name_id.presence
+    end
+
+    def call
+      names = Name.select('names.*, taxa.id AS taxon_id, protonyms.id AS protonym_id').
+        left_outer_joins(:taxa, :protonyms).
+        where("taxa.id IS NOT NULL OR protonyms.id IS NOT NULL")
+
+      case number_of_words
+      when SINGLE_WORD_NAMES_ONLY
+        names = names.single_word_names
+      when NO_SINGLE_WORD_NAMES
+        names = names.no_single_word_names
+      end
+
+      if except_name_id
+        names = names.where.not(id: except_name_id)
+      end
+
+      names.where("names.name LIKE ?", wildcard_search_query).limit(NUM_ITEMS)
+    end
+
+    private
+
+      attr_reader :search_query, :number_of_words, :except_name_id
+
+      def wildcard_search_query
+        search_query.split(' ').join('%') + '%'
+      end
+  end
+end

--- a/app/views/names/_form.haml
+++ b/app/views/names/_form.haml
@@ -27,6 +27,14 @@
 
 .row
   .medium-8.columns
+    -if @name.what_links_here.size > 1
+      .callout.alert
+        =antcat_icon 'warning-icon'
+        %strong Warning!
+        This name is used by more than one taxon/protonym.
+        Please check
+        =link_to 'What Links Here', name_path(name), class: 'btn-normal btn-very-tiny'
+
     =form_for name, url: name_path(name) do |f|
       =render 'shared/errors_for', resource: name
       =hidden_field_tag :type, @name.type
@@ -63,11 +71,8 @@
         %strong Consider this an advanced feature.
       %p
         =antcat_icon 'warning-icon'
-        This form allows saving of duplicates and homonyms. There are no validations for this.
+        This form allows saving of duplicates and homonyms.
       %p
         =antcat_icon 'warning-icon'
         Saving this form will update the name in place.
         The new name will be changed for all records referencing this name will.
-        Please check
-        =link_to 'What Links Here', name_path(name), class: 'btn-normal btn-very-tiny'
-        before saving.

--- a/app/views/names/_form.haml
+++ b/app/views/names/_form.haml
@@ -1,3 +1,6 @@
+-content_for :head do
+  =javascript_include_tag 'check_name_conflicts'
+
 =content_for :breadcrumbs_right do
   =link_to "Hide/show additional help", "#", class: "btn-nodanger", data: { show_hide_toggler_for: "additional-help" }
 
@@ -32,7 +35,12 @@
         %tbody
           %tr
             %th=f.label :name
-            %td.grow=f.text_field :name
+            %td.grow=f.text_field :name, id: 'name_name_string', data: { name_id: @name.id }
+          %tr
+            %td
+            %td
+              #name_name_string-possible-conflicts-js-hook.possible-name-conflicts
+
           %tr
             %th=f.label :epithet
             %td=f.text_field :epithet

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,7 @@ Rails.application.routes.draw do
     end
   end
 
+  get 'names/check_name_conflicts' => 'names/check_name_conflicts#show'
   resources :names, only: [:show, :edit, :update, :destroy] do
     scope module: :names do
       resources :history, only: :index

--- a/features/names/manage.feature
+++ b/features/names/manage.feature
@@ -1,0 +1,52 @@
+Feature: Manage names
+  Background:
+    Given I log in as a catalog editor named "Archibald"
+
+  @feed
+  Scenario: Editing a name (with feed)
+    Given there is a genus protonym "Formica"
+
+    When I go to the protonyms page
+    And I follow "Formica"
+    And I follow "Name record"
+    Then I should see "Name record: Formica"
+
+    When I follow "Edit"
+    Then I should see "Formica"
+    And I should not see "Similar names"
+    And I should not see "Formicus"
+
+    When I fill in "name_name_string" with "Lasius"
+    And I fill in "genus_name_epithet" with "Lasius"
+    And I fill in "edit_summary" with "fix name"
+    And I press "Save"
+    Then I should see "Successfully updated name."
+    And I should see "Name record: Lasius"
+
+    When I go to the activity feed
+    Then I should see "Archibald edited the name Lasius" and no other feed items
+    And I should see the edit summary "fix name"
+
+  @javascript
+  Scenario: Checking for name conflicts
+    Given there is a genus protonym "Formica"
+    And there is a genus protonym "Formica"
+    And there is a genus protonym "Formicus"
+
+    When I go to the protonyms page
+    And I follow the first "Formica"
+    And I follow "Name record"
+    And I follow "Edit"
+    Then I should not see "Similar names"
+    And I should not see "Formica (protonym)"
+    And I should not see "Formicus (protonym)"
+
+    When I fill in "name_name_string" with "formi"
+    And WAIT_FOR_JQUERY
+    Then I should see "Similar names"
+    And I should see "Formica (protonym)"
+    And I should see "Formicus (protonym)"
+
+    When I fill in "name_name_string" with "formica"
+    And WAIT_FOR_JQUERY
+    And I should see "Homonym Formica (protonym)"

--- a/features/step_definitions/protonym_steps.rb
+++ b/features/step_definitions/protonym_steps.rb
@@ -4,6 +4,11 @@ Given("there is a genus protonym {string} with pages and form 'page 9, dealate q
   create :protonym, name: name, authorship: citation
 end
 
+Given("there is a genus protonym {string}") do |name_string|
+  name = create :genus_name, name: name_string
+  create :protonym, name: name
+end
+
 When("I pick {string} from the protonym selector") do |name|
   select2 name, from: 'taxon_protonym_id'
 end

--- a/spec/controllers/names/check_name_conflicts_controller_spec.rb
+++ b/spec/controllers/names/check_name_conflicts_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Names::CheckNameConflictsController do
+  describe 'GET show' do
+    let!(:protonym) { create :protonym, name: create(:subfamily_name, name: 'Antcatinae') }
+    let!(:taxon) { create :family, name: create(:family_name, name: 'Antcatidae'), protonym: protonym }
+
+    specify do
+      get :show, params: { qq: 'Antc' }
+
+      expect(json_response).to eq(
+        [
+          {
+            "id" => taxon.name.id,
+            "name" => "Antcatidae",
+            "name_html" => "Antcatidae",
+            "protonym_id" => nil,
+            "taxon_id" => taxon.id
+          },
+          {
+            "id" => protonym.name.id,
+            "name" => "Antcatinae",
+            "name_html" => "Antcatinae",
+            "protonym_id" => protonym.id,
+            "taxon_id" => nil
+          }
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
Meta issue: #604

This will be used in the taxon form, but we want to disable editing names in the taxon and protonym forms before that, and before that we want to dedup name records (#662).