### PR TITLE
Replace missing reference button (AntCat 3.0.24)

### DIFF
--- a/app/controllers/references/replace_missing_controller.rb
+++ b/app/controllers/references/replace_missing_controller.rb
@@ -1,0 +1,53 @@
+# TODO: Remove once http://antcat.org/database_scripts/missing_references has been cleared.
+
+module References
+  class ReplaceMissingController < ApplicationController
+    before_action :ensure_can_edit_catalog
+    before_action :set_missing_reference
+    before_action :set_target_reference, only: :create
+
+    def show
+      @table_refs = @missing_reference.what_links_here.paginate(page: params[:page], per_page: 100)
+    end
+
+    def create
+      unless @target_reference
+        redirect_to({ action: :new }, alert: "Target must be specified.")
+        return
+      end
+
+      replace_missing!
+
+      create_activity
+      destroy_missing_reference
+
+      redirect_to reference_path(@target_reference), notice: "Replaced the missing refenrece #{@missing_reference.keey}."
+    end
+
+    private
+
+      def set_missing_reference
+        @missing_reference = Reference.find(params[:id])
+      end
+
+      def set_target_reference
+        @target_reference = Reference.find(params[:target_reference_id])
+      end
+
+      def replace_missing!
+        References::ReplaceMissing[@missing_reference, @target_reference]
+      end
+
+      def create_activity
+        @missing_reference.create_activity :replace_missing_reference, parameters: {
+          citation: @missing_reference.citation,
+          target_reference_id: @target_reference.id
+        }
+      end
+
+      def destroy_missing_reference
+        @missing_reference.destroy
+        @missing_reference.create_activity :destroy
+      end
+  end
+end

--- a/app/database_scripts/database_scripts/missing_references.rb
+++ b/app/database_scripts/database_scripts/missing_references.rb
@@ -9,12 +9,13 @@ module DatabaseScripts
 
     def render
       as_table do |t|
-        t.header :id, :reference, :what_link_here
+        t.header :id, :reference, :what_link_here, :replace
         t.rows do |reference|
           [
             link_to(reference.id, reference_path(reference)),
             markdown_reference_link(reference),
-            link_to("What Links Here", reference_what_links_here_index_path(reference), class: "btn-normal btn-tiny")
+            link_to("What Links Here", reference_what_links_here_index_path(reference), class: "btn-normal btn-tiny"),
+            link_to('Replace', replace_missing_path(reference), class: 'btn-normal btn-tiny')
           ]
         end
       end

--- a/app/helpers/reference_select_helper.rb
+++ b/app/helpers/reference_select_helper.rb
@@ -1,4 +1,13 @@
 module ReferenceSelectHelper
+  def reference_select_tag reference_attribute_name, reference_id
+    reference = Reference.find_by(id: reference_id)
+    reference_id = reference&.id
+
+    select_tag reference_attribute_name,
+      options_for_select([reference_id].compact, reference_id),
+      class: 'select2-autocomplete', data: reference_data_attributes(reference)
+  end
+
   private
 
     def reference_data_attributes reference

--- a/app/helpers/taxon_helper.rb
+++ b/app/helpers/taxon_helper.rb
@@ -8,6 +8,15 @@ module TaxonHelper
     end
   end
 
+  def reference_link_or_deleted_string id, deleted_label = nil
+    reference = Reference.find_by(id: id)
+    if reference
+      reference.decorate.expandable_reference
+    else
+      deleted_label || "##{id} [deleted]"
+    end
+  end
+
   def default_name_string taxon
     return unless taxon.is_a?(SpeciesGroupTaxon) || taxon.is_a?(Subgenus)
     return taxon.species.name.name if taxon.is_a?(Subspecies)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -29,6 +29,7 @@ class Activity < ApplicationRecord
     reopen_feedback
     reopen_issue
     reorder_taxon_history_items
+    replace_missing_reference
     restart_reviewing
     start_reviewing
     undo_change

--- a/app/services/references/replace_missing.rb
+++ b/app/services/references/replace_missing.rb
@@ -1,0 +1,38 @@
+module References
+  class ReplaceMissing
+    include Service
+
+    def initialize missing_reference, target_reference
+      @missing_reference = missing_reference
+      @target_reference = target_reference
+    end
+
+    def call
+      # These cases should not happen, but let's raise if that happens.
+      raise 'must be missing' unless missing_reference.is_a? MissingReference
+      raise 'cannot have nestees' if missing_reference.nestees.exists?
+      raise 'cannot have linked citations' if Citation.where(reference: missing_reference).exists?
+
+      replace_all!
+    end
+
+    private
+
+      attr_reader :missing_reference, :target_reference
+
+      def replace_all!
+        Taxt::TAXT_MODELS_AND_FIELDS.each do |(model, field)|
+          model.where("#{field} LIKE '%{ref #{missing_reference.id}}%'").find_each do |match|
+            content = match.public_send(field)
+            new_content = replace_ref_tags content
+            match.public_send("#{field}=", new_content)
+            match.save!
+          end
+        end
+      end
+
+      def replace_ref_tags content
+        content.gsub("{ref #{missing_reference.id}}", "{ref #{target_reference.id}}")
+      end
+  end
+end

--- a/app/views/activities/templates/actions/_replace_missing_reference.haml
+++ b/app/views/activities/templates/actions/_replace_missing_reference.haml
@@ -1,0 +1,7 @@
+replaced the missing reference
+
+=activity.link_trackable_if_exists sanitize(activity.parameters[:citation]), path: reference_path(activity.trackable_id)
+
+with
+
+=reference_link_or_deleted_string activity.parameters[:target_reference_id]

--- a/app/views/references/replace_missing/show.haml
+++ b/app/views/references/replace_missing/show.haml
@@ -1,0 +1,56 @@
+-@title = "Replace missing reference"
+-breadcrumb :replace_missing_reference, @missing_reference
+
+-content_for :head do
+  =javascript_include_tag "reference_select"
+
+.row
+  .medium-12.columns
+    .callout
+      %p
+        =antcat_icon 'warning-icon'
+        This action cannot be undone.
+
+      %p
+        Select a target reference and click on "Replace!" to replace all occurences of the missing reference with the target reference
+        %em en masse.
+        The missing reference will then be deleted.
+
+      %p
+        Please check all 'What Links Here' first and confirm that all of them should be replaced with the target reference. It is not possible to check which replacements were made after the action has been perform, so keep this page or
+        =link_to("What Links Here", reference_what_links_here_index_path(@missing_reference), class: "btn-normal btn-tiny")
+        open in another new tab if you want to see the old 'What Links Here', and like mentioned earlier, it's not possible to undo this action.
+
+      %p
+        If you replace a reference by mistake, try to repair it via the 'What Links Here' of the new reference, and if things gets really messy, just reach out to me (Fredrik).
+        =link_to "PaperTrail versions", versions_path
+        can also be used to some extent (go to the last page).
+
+=form_tag replace_missing_path(@missing_reference) do
+  .row
+    .medium-12.columns
+      .row
+        .medium-8.columns
+          %fieldset.fieldset
+            %legend Missing reference to be replaced
+            %p=@missing_reference.decorate.expanded_reference
+            %p
+              Reason missing:
+              =@missing_reference.reason_missing
+
+            %hr
+
+            %h5 What Links Here
+            =render "shared/what_links_here", table_refs: @table_refs
+            =will_paginate @table_refs
+
+        .medium-4.columns
+          %fieldset.fieldset
+            %legend Replace with
+            %p=reference_select_tag :target_reference_id, params[:target_reference_id]
+
+      .row
+        .medium-12.columns
+          .center-text
+            =button_tag type: "submit", class: "btn-warning has-spinner" do
+              =spinner_icon + "Replace!"

--- a/app/views/references/show.haml
+++ b/app/views/references/show.haml
@@ -44,6 +44,9 @@
         Reason missing:
         =@reference.reason_missing
 
+        -if user_is_editor?
+          =link_to 'Replace', replace_missing_path(@reference), class: 'btn-normal btn-tiny'
+
 .row.margin-bottom
   .small-12.columns
     .callout

--- a/config/breadcrumbs/references.rb
+++ b/config/breadcrumbs/references.rb
@@ -28,6 +28,11 @@ end
     parent :reference, reference
   end
 
+  crumb :replace_missing_reference do |reference|
+    link "Replace"
+    parent :reference, reference
+  end
+
 crumb :references_search_results do
   link "Search Results"
   parent :references

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,8 @@ Rails.application.routes.draw do
           post :restart
         end
 
+        resource :replace_missing, only: [:show, :create], controller: :replace_missing
+
         scope :exports, controller: :exports, as: :export do
           get :wikipedia
         end


### PR DESCRIPTION
Closes #661

No specs, since it's Temporary Code(tm) we can remove once  http://antcat.org/database_scripts/missing_references has been cleared.

---

##### TODO
- [ ] Download db dump
- [x] Draft site notice
- [ ] Merge to `master`
- [ ] Tag release
- [ ] Deploy to live
- [ ] Other things to not forget (run data migrations, invalidate reference caches)
- [ ] Make sure Solr is working ([test reference](http://antcat.org/references/143068/edit))
- [ ] Add site notice
- [ ] GitHub cleanup (close issues etc)