### PR TITLE
Associate activities and versions with the request

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
 
   before_action :save_location
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :set_paper_trail_whodunnit
+  before_action :set_paper_trail_whodunnit, :set_current_request_uuid
 
   skip_before_action :verify_authenticity_token
   before_action :cors_preflight_check
@@ -62,6 +62,10 @@ class ApplicationController < ActionController::Base
       headers['Access-Control-Max-Age'] = '1728000'
 
       render plain: ''
+    end
+
+    def set_current_request_uuid
+      RequestStore.store[:current_request_uuid] = SecureRandom.uuid
     end
 
     def ensure_unconfirmed_user_is_not_over_edit_limit

--- a/app/controllers/editors_panels/versions_controller.rb
+++ b/app/controllers/editors_panels/versions_controller.rb
@@ -45,7 +45,7 @@ module EditorsPanels
     private
 
       def filter_params
-        params.permit(:whodunnit, :item_type, :item_id, :event, :change_id)
+        params.permit(:whodunnit, :item_type, :item_id, :event, :change_id, :request_uuid)
       end
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -2,6 +2,8 @@
 # set to true and `user` set to a user named "AntCatBot" (`User.find 62`).
 
 class Activity < ApplicationRecord
+  include SetRequestUuid
+
   EDIT_SUMMARY_MAX_LENGTH = 255
   ACTIONS = %w[
     create

--- a/app/models/concerns/set_request_uuid.rb
+++ b/app/models/concerns/set_request_uuid.rb
@@ -1,0 +1,13 @@
+module SetRequestUuid
+  extend ActiveSupport::Concern
+
+  included do
+    before_create :set_request_uuid
+  end
+
+  private
+
+    def set_request_uuid
+      self.request_uuid = RequestStore.read(:current_request_uuid)
+    end
+end

--- a/app/models/paper_trail/version.rb
+++ b/app/models/paper_trail/version.rb
@@ -1,6 +1,7 @@
 module PaperTrail
   class Version < ApplicationRecord
     include PaperTrail::VersionConcern
+    include SetRequestUuid
 
     belongs_to :change
 

--- a/app/views/activities/_table.haml
+++ b/app/views/activities/_table.haml
@@ -20,7 +20,10 @@
               .gray-text.with-gray-links
                 Edit summary:
                 =markdown activity.edit_summary, no_wrapping_p: true
-          %td=decorated.revision_history_link
+          %td
+            =decorated.revision_history_link
+            -if activity.request_uuid
+              =link_to 'uuid', versions_path(request_uuid: activity.request_uuid), class: "btn-normal btn-tiny"
           %td.activity-link-wrapper.no-wrap
             %span.hide-on-hover=decorated.when
             %span.show-on-hover

--- a/app/views/editors_panels/versions/index.haml
+++ b/app/views/editors_panels/versions/index.haml
@@ -16,10 +16,11 @@
 
   .row
     .small-6.medium-4.large-2.columns
+      =text_field_tag :request_uuid, params[:request_uuid], placeholder: 'Request UUID'
+    .small-6.medium-4.large-2.columns
       =select_tag :search_type, options_for_select([["LIKE (default)", "LIKE"], ["REGEXP (slow)", "REGEXP"]], params[:search_type]), prompt: "Search type"
     .small-6.medium-4.large-2.columns
       =text_field_tag :q, params[:q], placeholder: "Search query"
-
     .small-6.medium-4.large-2.columns.end
       =button_tag type: "submit", name: nil, class: "btn-normal has-spinner" do
         =spinner_icon + "Filter"

--- a/db/migrate/20200124181539_add_request_uuid_to_versions_and_activities.rb
+++ b/db/migrate/20200124181539_add_request_uuid_to_versions_and_activities.rb
@@ -1,0 +1,9 @@
+class AddRequestUuidToVersionsAndActivities < ActiveRecord::Migration[5.2]
+  def change
+    add_column :versions, :request_uuid, :string
+    add_index :versions, :request_uuid
+
+    add_column :activities, :request_uuid, :string
+    add_index :activities, :request_uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_24_181538) do
+ActiveRecord::Schema.define(version: 2020_01_24_181539) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "trackable_id"
@@ -22,6 +22,8 @@ ActiveRecord::Schema.define(version: 2020_01_24_181538) do
     t.datetime "updated_at", null: false
     t.string "edit_summary"
     t.boolean "automated_edit", default: false, null: false
+    t.string "request_uuid"
+    t.index ["request_uuid"], name: "index_activities_on_request_uuid"
     t.index ["trackable_id", "trackable_type"], name: "index_activities_on_trackable_id_and_trackable_type"
     t.index ["user_id"], name: "index_activities_on_user_id"
   end
@@ -381,10 +383,12 @@ ActiveRecord::Schema.define(version: 2020_01_24_181538) do
     t.datetime "created_at"
     t.text "object_changes"
     t.integer "change_id"
+    t.string "request_uuid"
     t.index ["change_id"], name: "index_versions_on_change_id"
     t.index ["event"], name: "index_versions_on_event"
     t.index ["item_id"], name: "index_versions_on_item_id"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
+    t.index ["request_uuid"], name: "index_versions_on_request_uuid"
     t.index ["whodunnit"], name: "index_versions_on_whodunnit"
   end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -5,6 +5,10 @@ describe Activity do
   it { is_expected.to validate_presence_of :action }
   it { is_expected.to validate_inclusion_of(:action).in_array Activity::ACTIONS }
 
+  it_behaves_like "a model that assigns `request_id` on create" do
+    let(:instance) { build :activity }
+  end
+
   describe ".create_for_trackable" do
     let(:trackable) { nil }
 

--- a/spec/models/paper_trail/version_spec.rb
+++ b/spec/models/paper_trail/version_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 describe PaperTrail::Version do
+  it_behaves_like "a model that assigns `request_id` on create" do
+    let!(:item) { create :user }
+    let(:instance) { build :version, item: item }
+  end
+
   describe "#user" do
     context 'when version has a whodunnit' do
       let!(:user) { create :user }

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe ApplicationController do
+  describe '#set_current_request_uuid' do
+    let!(:request_uuid) { SecureRandom.uuid }
+    let!(:protonym) { create :protonym }
+    let(:params) do
+      {
+        protonym: { fossil: false }
+      }
+    end
+
+    before do
+      allow(SecureRandom).to receive(:uuid).and_return(request_uuid)
+      sign_in create(:user, :helper)
+    end
+
+    it 'assigns `request_uuid` to activities' do
+      expect { put protonym_path(protonym), params: params }.to change { Activity.count }
+
+      activity = Activity.last
+      expect(activity.request_uuid).to eq request_uuid
+    end
+
+    it 'assigns `request_uuid` to versions', :versioning do
+      expect { put protonym_path(protonym), params: params }.to change { PaperTrail::Version.count }
+
+      version = PaperTrail::Version.last
+      expect(version.request_uuid).to eq request_uuid
+    end
+  end
+end

--- a/spec/support/rspec.rb
+++ b/spec/support/rspec.rb
@@ -29,6 +29,7 @@ RSpec.configure do |config|
 
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include JsonResponseHelper, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :request
   config.include FactoryBot::Syntax::Methods # To avoid typing `FactoryBot.create`.
 
   RSpec::Matchers.define_negated_matcher :not_change, :change

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -29,3 +29,16 @@ shared_examples_for "a taxt column with cleanup" do |column|
     expect { subject.valid? }.to change { subject.public_send(column) }.from('Pi   zz : : a').to('Pi zz: a')
   end
 end
+
+shared_examples_for "a model that assigns `request_id` on create" do
+  let!(:current_request_uuid) { SecureRandom.uuid }
+
+  before do
+    allow(RequestStore.store).to receive(:[]).with(:current_request_uuid).and_return(current_request_uuid)
+  end
+
+  it 'assigns `request_uuid`' do
+    expect { instance.save! }.to change { instance.request_uuid }.
+      from(nil).to(current_request_uuid)
+  end
+end


### PR DESCRIPTION
To be able to track all changes that were created during a particular request. Useful for investigating complicated changes, and for reversing a change.