### PR TITLE
Refactor reference form (pagination)

### DIFF
--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -17,7 +17,7 @@ class ReferencesController < ApplicationController
     @reference = if params[:nesting_reference_id]
                    NestedReference.new(
                      citation_year: params[:citation_year],
-                     pages_in: "Pp. XX-XX in:",
+                     pagination: "Pp. XX-XX in:",
                      nesting_reference_id: params[:nesting_reference_id]
                    )
                  elsif params[:reference_to_copy]
@@ -95,7 +95,6 @@ class ReferencesController < ApplicationController
         :journal_name,
         :nesting_reference_id,
         :online_early,
-        :pages_in,
         :pagination,
         :public_notes,
         :publisher_string,

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -68,7 +68,7 @@ class ReferencesController < ApplicationController
   private
 
     def save
-      ReferenceForm.new(@reference, reference_params, params, request.host).save
+      ReferenceForm.new(@reference, reference_params, request.host, ignore_duplicates: params[:ignore_duplicates].present?).save
     end
 
     def set_reference_type

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -96,6 +96,7 @@ class ReferencesController < ApplicationController
         :nesting_reference_id,
         :online_early,
         :pages_in,
+        :pagination,
         :public_notes,
         :publisher_string,
         :series_volume_issue,

--- a/app/formatters/reference_formatter.rb
+++ b/app/formatters/reference_formatter.rb
@@ -51,7 +51,7 @@ class ReferenceFormatter
       when BookReference
         "#{reference.publisher.display_name}, #{reference.pagination}"
       when NestedReference
-        "#{reference.pages_in} #{sanitize ReferenceFormatter.new(reference.nesting_reference).expanded_reference}"
+        "#{reference.pagination} #{sanitize ReferenceFormatter.new(reference.nesting_reference).expanded_reference}"
       when MissingReference, UnknownReference
         reference.citation
       else
@@ -96,7 +96,7 @@ class ReferenceFormatter
     def format_plain_text_citation
       case reference
       when NestedReference
-        sanitize "#{reference.pages_in} #{ReferenceFormatter.new(reference.nesting_reference).plain_text}"
+        sanitize "#{reference.pagination} #{ReferenceFormatter.new(reference.nesting_reference).plain_text}"
       else
         Unitalicize[format_italics(sanitize(format_citation))]
       end

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -54,7 +54,7 @@ class ReferenceForm
       string = params.delete(:author_names_string)
       return if string.strip == reference.author_names_string
 
-      author_names = Authors::FindOrCreateNamesFromString[string.dup]
+      author_names = Authors::FindOrInitializeNamesFromString[string.dup]
 
       if author_names.empty? && string.present?
         reference.errors.add :author_names_string, "couldn't be parsed."

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -1,6 +1,6 @@
-# NOTE: This service mutates `params`, but that's OK for now.
-
 class ReferenceForm
+  POSSIBLE_DUPLICATE_ERROR_KEY = :possible_duplicate # HACK: To get rid of other hack.
+
   def initialize reference, reference_params, original_params, request_host
     @reference = reference
     @params = reference_params
@@ -30,9 +30,8 @@ class ReferenceForm
         # before validating, so we need to manually raise here.
         raise ActiveRecord::Rollback if reference.errors.present?
 
-        if original_params[:ignore_possible_duplicate].blank?
+        if original_params[:ignore_duplicates].blank?
           if check_for_duplicates!
-            original_params[:ignore_possible_duplicate] = "yes"
             raise ActiveRecord::Rollback
           end
         end
@@ -105,7 +104,7 @@ class ReferenceForm
       return if duplicates.blank?
 
       duplicate = Reference.find(duplicates.first[:match].id)
-      reference.errors.add :base, <<~MSG.html_safe
+      reference.errors.add POSSIBLE_DUPLICATE_ERROR_KEY, <<~MSG.html_safe
         This may be a duplicate of #{duplicate.keey} (##{duplicate.id}).<br>
         To save, click "Save".
       MSG

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -1,11 +1,11 @@
 class ReferenceForm
   POSSIBLE_DUPLICATE_ERROR_KEY = :possible_duplicate # HACK: To get rid of other hack.
 
-  def initialize reference, reference_params, original_params, request_host
+  def initialize reference, params, request_host, ignore_duplicates: false
     @reference = reference
-    @params = reference_params
-    @original_params = original_params
+    @params = params
     @request_host = request_host
+    @ignore_duplicates = ignore_duplicates
   end
 
   def save
@@ -14,7 +14,7 @@ class ReferenceForm
 
   private
 
-    attr_reader :reference, :params, :original_params, :request_host
+    attr_reader :reference, :params, :request_host, :ignore_duplicates
 
     def save_reference
       Reference.transaction do
@@ -30,7 +30,7 @@ class ReferenceForm
         # before validating, so we need to manually raise here.
         raise ActiveRecord::Rollback if reference.errors.present?
 
-        if original_params[:ignore_duplicates].blank?
+        unless ignore_duplicates
           if check_for_duplicates!
             raise ActiveRecord::Rollback
           end

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -19,7 +19,6 @@ class ReferenceForm
     def save_reference
       Reference.transaction do
         clear_document_params_if_necessary
-        set_pagination
         parse_author_names_string
         set_journal if reference.is_a? ::ArticleReference
         set_publisher if reference.is_a? ::BookReference
@@ -45,14 +44,6 @@ class ReferenceForm
       end
     rescue ActiveRecord::RecordInvalid
       false
-    end
-
-    def set_pagination
-      params[:pagination] =
-        case reference
-        when ArticleReference then original_params[:article_pagination]
-        when BookReference    then original_params[:book_pagination]
-        end
     end
 
     def set_document_host

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -62,7 +62,6 @@ class ReferenceForm
         raise ActiveRecord::RecordInvalid, reference
       end
 
-      reference.author_names.clear
       params[:author_names] = author_names
     end
 

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -50,7 +50,7 @@ class Reference < ApplicationRecord
   strip_attributes only: [
     :editor_notes, :public_notes, :taxonomic_notes, :title,
     :citation, :date, :citation_year, :series_volume_issue, :pagination,
-    :pages_in, :doi, :reason_missing, :review_state, :bolton_key, :author_names_suffix
+     :doi, :reason_missing, :review_state, :bolton_key, :author_names_suffix
   ], replace_newlines: true
   trackable parameters: proc { { name: keey } }
 

--- a/app/models/references/nested_reference.rb
+++ b/app/models/references/nested_reference.rb
@@ -1,7 +1,7 @@
 class NestedReference < Reference
   belongs_to :nesting_reference, class_name: 'Reference'
 
-  validates :year, :pages_in, presence: true
+  validates :year, :pagination, presence: true
   validates :nesting_reference, presence: { message: "does not exist" }
   validate :validate_nested_reference_doesnt_point_to_itself
 

--- a/app/services/authors/find_or_initialize_names_from_string.rb
+++ b/app/services/authors/find_or_initialize_names_from_string.rb
@@ -1,5 +1,5 @@
 module Authors
-  class FindOrCreateNamesFromString
+  class FindOrInitializeNamesFromString
     include Service
 
     def initialize string
@@ -9,7 +9,7 @@ module Authors
     def call
       parsed_author_names.map do |name|
         AuthorName.where(name: name).find { |case_sensitive_name| case_sensitive_name.name == name } ||
-          AuthorName.create!(name: name, author: Author.create!)
+          AuthorName.new(name: name, author: Author.new)
       end
     end
 

--- a/app/services/autocomplete/format_linkable_references.rb
+++ b/app/services/autocomplete/format_linkable_references.rb
@@ -25,7 +25,7 @@ module Autocomplete
 
       def full_pagination reference
         if reference.is_a? NestedReference
-          "[pagination: #{reference.pages_in} (#{reference.nesting_reference.pagination})]"
+          "[pagination: #{reference.pagination} (#{reference.nesting_reference.pagination})]"
         elsif reference.pagination
           "[pagination: #{reference.pagination}]"
         else

--- a/app/services/references/new_from_copy.rb
+++ b/app/services/references/new_from_copy.rb
@@ -24,7 +24,7 @@ module References
         case original
         when ::ArticleReference then [:series_volume_issue, :journal_id]
         when ::BookReference    then [:publisher_id]
-        when ::NestedReference  then [:pages_in, :nesting_reference_id]
+        when ::NestedReference  then [:nesting_reference_id]
         when ::UnknownReference then [:citation]
         else                         []
         end

--- a/app/views/references/_form.haml
+++ b/app/views/references/_form.haml
@@ -44,6 +44,7 @@
         Pagination
         =db_tooltip_icon "references.journal_pagination", scope: :references
         =db_tooltip_icon "references.book_pagination", scope: :references
+        =db_tooltip_icon "references.nested_pagination", scope: :references
       =f.text_field :pagination
     .medium-4.columns
       =label_tag :reference_doi do
@@ -100,12 +101,6 @@
 
         #tabs-nested.tabs-panel{class: reference_tab_active?(reference, NestedReference)}
           .row
-            .medium-3.columns
-              =label_tag :reference_pages_in do
-                Pages in
-                =db_tooltip_icon "references.nested_pagination", scope: :references
-              =f.text_field :pages_in
-
             .medium-3.columns.end
               =label_tag :nesting_reference_id do
                 Nesting reference ID

--- a/app/views/references/_form.haml
+++ b/app/views/references/_form.haml
@@ -10,7 +10,7 @@
 
 =form_for reference.becomes(Reference) do |f|
   =hidden_field_tag :reference_type, reference.class.name
-  =hidden_field_tag :ignore_possible_duplicate, ignore_possible_duplicate
+  =hidden_field_tag :ignore_duplicates, ('yes' if reference.errors.has_key?(ReferenceForm::POSSIBLE_DUPLICATE_ERROR_KEY))
   =render 'shared/errors_for', resource: reference
 
   .row

--- a/app/views/references/_form.haml
+++ b/app/views/references/_form.haml
@@ -39,6 +39,12 @@
         =f.check_box :online_early
         Online early
   .row
+    .medium-2.columns
+      =label_tag :reference_pagination do
+        Pagination
+        =db_tooltip_icon "references.journal_pagination", scope: :references
+        =db_tooltip_icon "references.book_pagination", scope: :references
+      =f.text_field :pagination
     .medium-4.columns
       =label_tag :reference_doi do
         DOI
@@ -84,12 +90,6 @@
                 =db_tooltip_icon "references.series_volume_issue", scope: :references
               =f.text_field :series_volume_issue
 
-            .medium-3.columns.end
-              =label_tag :article_pagination do
-                Pagination
-                =db_tooltip_icon "references.journal_pagination", scope: :references
-              =text_field_tag :article_pagination, reference.pagination
-
         #tabs-book.tabs-panel{class: reference_tab_active?(reference, BookReference)}
           .row
             .medium-3.columns
@@ -97,12 +97,6 @@
                 Publisher
                 =db_tooltip_icon "references.publisher", scope: :references
               =f.text_field :publisher_string, value: reference.publisher_string
-
-            .medium-3.columns.end
-              =label_tag :book_pagination do
-                Pagination
-                =db_tooltip_icon "references.book_pagination", scope: :references
-              =text_field_tag :book_pagination, reference.pagination
 
         #tabs-nested.tabs-panel{class: reference_tab_active?(reference, NestedReference)}
           .row

--- a/app/views/references/edit.haml
+++ b/app/views/references/edit.haml
@@ -1,4 +1,4 @@
 -@title = "Edit Reference ##{@reference.id}"
 -breadcrumb :edit_reference, @reference
 
-=render 'form', reference: @reference, ignore_possible_duplicate: params[:ignore_possible_duplicate]
+=render 'form', reference: @reference

--- a/app/views/references/new.haml
+++ b/app/views/references/new.haml
@@ -1,4 +1,4 @@
 -@title = "New Reference"
 -breadcrumb :new_reference
 
-=render 'form', reference: @reference, ignore_possible_duplicate: params[:ignore_possible_duplicate]
+=render 'form', reference: @reference

--- a/app/views/references/show.haml
+++ b/app/views/references/show.haml
@@ -79,11 +79,7 @@
             %td=@reference.citation
         %tr
           %th Pagination
-          %td
-            -if @reference.is_a? NestedReference
-              =or_dash @reference.pages_in
-            -else
-              =or_dash @reference.pagination
+          %td=or_dash @reference.pagination
         %tr
           %th Date
           %td

--- a/db/migrate/20200202204901_copy_references_pages_in_to_pagination.rb
+++ b/db/migrate/20200202204901_copy_references_pages_in_to_pagination.rb
@@ -1,0 +1,15 @@
+# TODO: Remove `references.pages_in`.
+
+class CopyReferencesPagesInToPagination < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+      UPDATE `references` SET pagination = pages_in WHERE type = 'NestedReference'
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE `references` SET pages_in = pagination WHERE type = 'NestedReference'
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_24_181539) do
+ActiveRecord::Schema.define(version: 2020_02_02_204901) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "trackable_id"

--- a/features/reference_form/add_reference_successfully.feature
+++ b/features/reference_form/add_reference_successfully.feature
@@ -11,7 +11,7 @@ Feature: Add reference
     And I fill in "reference_bolton_key" with "Ward, B.L. & Bolton, B., 1981a"
     And I fill in "reference_journal_name" with "Ant Journal"
     And I fill in "reference_series_volume_issue" with "1"
-    And I fill in "article_pagination" with "2"
+    And I fill in "reference_pagination" with "2"
     And I press "Save"
     Then I should see "Ward, B.L.; Bolton, B. 1981. A reference title. Ant Journal 1:2"
     And I should see "Ward, B.L. & Bolton, B., 1981a"
@@ -23,7 +23,7 @@ Feature: Add reference
     And I fill in "reference_citation_year" with "1981"
     And I follow "Book"
     And I fill in "reference_publisher_string" with "New York: Houghton Mifflin"
-    And I fill in "book_pagination" with "32 pp."
+    And I fill in "reference_pagination" with "32 pp."
     And I press "Save"
     Then I should see "Ward, B.L.; Bolton, B. 1981. A reference title. New York: Houghton Mifflin, 32 pp."
 

--- a/features/reference_form/add_reference_successfully.feature
+++ b/features/reference_form/add_reference_successfully.feature
@@ -37,7 +37,7 @@ Feature: Add reference
     And I fill in "reference_title" with "A reference title"
     And I fill in "reference_citation_year" with "1981"
     And I follow "Nested"
-    And I fill in "reference_pages_in" with "Pp. 32-33 in:"
+    And I fill in "reference_pagination" with "Pp. 32-33 in:"
     And I fill in "reference_nesting_reference_id" with the ID for "Annals of Ants"
     And I press "Save"
     Then I should see "Ward, B.L.; Bolton, B. 1981. A reference title. Pp. 32-33 in: Ward, P.S. 2010. Annals of Ants. Psyche 1:1"

--- a/features/reference_form/add_reference_unsuccessfully.feature
+++ b/features/reference_form/add_reference_unsuccessfully.feature
@@ -7,26 +7,26 @@ Feature: Add reference unsuccessfully
   Scenario: Leaving a required field blank should not affect other fields (article)
     When I fill in "reference_title" with "A reference title"
     And I fill in "reference_journal_name" with "Ant Journal"
-    And I fill in "article_pagination" with "2"
+    And I fill in "reference_pagination" with "2"
     And I press "Save"
     Then the "reference_title" field should contain "A reference title"
 
     When I follow "Article"
     Then the "reference_journal_name" field should contain "Ant Journal"
-    And the "article_pagination" field should contain "2"
+    And the "reference_pagination" field should contain "2"
 
   @javascript
   Scenario: Leaving a required field blank should not affect other fields (book)
     When I follow "Book"
     And I fill in "reference_title" with "A reference title"
     And I fill in "reference_publisher_string" with "Capua: House of Batiatus"
-    And I fill in "book_pagination" with "2"
+    And I fill in "reference_pagination" with "2"
     And I press "Save"
     Then the "reference_title" field should contain "A reference title"
 
     When I follow "Book"
     Then the "reference_publisher_string" field should contain "Capua: House of Batiatus"
-    And the "book_pagination" field should contain "2"
+    And the "reference_pagination" field should contain "2"
 
   Scenario: Unparseable author string (and maintain already filled in fields)
     When I fill in "reference_author_names_string" with "...asdf sdf dsfdsf"
@@ -39,25 +39,25 @@ Feature: Add reference unsuccessfully
     When I fill in "reference_title" with "A reference title"
     And I follow "Article"
     And I fill in "reference_journal_name" with ""
-    And I fill in "article_pagination" with "1"
+    And I fill in "reference_pagination" with "1"
     And I press "Save"
     Then I should see "Journal can't be blank"
     And the "reference_title" field should contain "A reference title"
 
     When I follow "Article"
     Then the "reference_journal_name" field should contain ""
-    And the "article_pagination" field should contain "1"
+    And the "reference_pagination" field should contain "1"
 
   @javascript
   Scenario: Unparseable publisher string (and maintain already filled in fields)
     When I fill in "reference_title" with "A reference title"
     And I follow "Book"
     And I fill in "reference_publisher_string" with "Pensoft, Sophia"
-    And I fill in "book_pagination" with "1"
+    And I fill in "reference_pagination" with "1"
     And I press "Save"
     Then I should see "Publisher string couldn't be parsed. In general, use the format 'Place: Publisher'."
 
     When I follow "Book"
     Then the "reference_title" field should contain "A reference title"
     And the "reference_publisher_string" field should contain "Pensoft, Sophia"
-    And the "book_pagination" field should contain "1"
+    And the "reference_pagination" field should contain "1"

--- a/features/reference_form/copy_reference.feature
+++ b/features/reference_form/copy_reference.feature
@@ -17,6 +17,6 @@ Feature: Copy reference
     Then the "Article" tab should be selected
     And the "reference_author_names_string" field should contain "Ward, P.S."
     And the "reference_citation_year" field should contain "1910"
-    And the "article_pagination" field should contain "2"
+    And the "reference_pagination" field should contain "2"
     And the "reference_journal_name" field should contain "Ants"
     And the "reference_series_volume_issue" field should contain "1"

--- a/features/reference_form/duplicate_checking.feature
+++ b/features/reference_form/duplicate_checking.feature
@@ -17,7 +17,7 @@ Feature: Checking for duplicates during data entry
     And I fill in "reference_series_volume_issue" with "6"
     And I fill in "reference_citation_year" with "2010"
     And I fill in "reference_journal_name" with "Psyche"
-    And I fill in "article_pagination" with "1"
+    And I fill in "reference_pagination" with "1"
     And I press "Save"
     Then I should see "This may be a duplicate of Ward, 2010"
 

--- a/features/reference_form/edit_reference_successfully.feature
+++ b/features/reference_form/edit_reference_successfully.feature
@@ -40,13 +40,13 @@ Feature: Edit reference successfully
       | author     | citation   | citation_year | title |
       | Ward, P.S. | Psyche 5:3 | 2001          | Ants  |
     And the following entry nests it
-      | author     | title            | citation_year | pages_in |
-      | Bolton, B. | Ants are my life | 2001          | In:      |
+      | author     | title            | citation_year | pagination |
+      | Bolton, B. | Ants are my life | 2001          | In:        |
 
     When I go to the references page
     Then I should see "Bolton, B. 2001. Ants are my life. In: Ward, P.S. 2001. Ants. Psyche 5:3"
 
     When I go to the edit page for the most recent reference
-    And I fill in "reference_pages_in" with "Pp. 32 in:"
+    And I fill in "reference_pagination" with "Pp. 32 in:"
     And I press "Save"
     Then I should see "Bolton, B. 2001. Ants are my life. Pp. 32 in: Ward, P.S. 2001. Ants. Psyche 5:3"

--- a/features/reference_form/edit_reference_successfully.feature
+++ b/features/reference_form/edit_reference_successfully.feature
@@ -11,7 +11,7 @@ Feature: Edit reference successfully
     When I go to the edit page for the most recent reference
     And I follow "Book"
     And I fill in "reference_publisher_string" with "New York: Wiley"
-    And I fill in "book_pagination" with "22 pp."
+    And I fill in "reference_pagination" with "22 pp."
     And I press "Save"
     Then I should see "Fisher, B. 2010. Ants. New York: Wiley, 22 pp."
 

--- a/features/reference_form/new_nested_reference_button.feature
+++ b/features/reference_form/new_nested_reference_button.feature
@@ -8,5 +8,5 @@ Feature: Add new nested reference button
     When I go to the page of the most recent reference
     And I follow "New Nested Reference"
     Then the "reference_citation_year" field should contain "2010"
-    And the "reference_pages_in" field should contain "Pp. XX-XX in:"
+    And the "reference_pagination" field should contain "Pp. XX-XX in:"
     And nesting_reference_id should contain a valid reference id

--- a/features/step_definitions/reference_steps.rb
+++ b/features/step_definitions/reference_steps.rb
@@ -44,7 +44,7 @@ Given("the following entry nests it") do |table|
     title: data[:title],
     author_names: [create(:author_name, name: data[:author])],
     citation_year: data[:citation_year],
-    pages_in: data[:pages_in],
+    pagination: data[:pagination],
     nesting_reference: Reference.last
   )
 end

--- a/spec/controllers/references_controller_spec.rb
+++ b/spec/controllers/references_controller_spec.rb
@@ -32,6 +32,7 @@ describe ReferencesController do
         title: 'New Ants',
         citation_year: '1999b',
         author_names_string: "Batiatus, B.; Glaber, G.",
+        pagination: '5',
         journal_name: 'Zootaxa',
         series_volume_issue: '6',
         date: "19991220",
@@ -45,7 +46,6 @@ describe ReferencesController do
     let!(:params) do
       {
         reference_type: 'ArticleReference',
-        article_pagination: '5',
         reference: reference_params
       }
     end
@@ -92,13 +92,13 @@ describe ReferencesController do
         title: 'Newer Ants',
         author_names_string: reference.author_names_string,
         journal_name: reference.journal.name,
-        online_early: true
+        online_early: true,
+        pagination: '5'
       }
     end
     let!(:params) do
       {
         reference_type: reference.type,
-        article_pagination: '5',
         id: reference.id,
         reference: reference_params
       }

--- a/spec/factories/references.rb
+++ b/spec/factories/references.rb
@@ -49,7 +49,7 @@ FactoryBot.define do
     end
 
     factory :nested_reference, class: 'NestedReference' do
-      pages_in { 'In: ' }
+      pagination { 'In: ' }
       nesting_reference { create :book_reference }
     end
 

--- a/spec/formatters/reference_formatter_spec.rb
+++ b/spec/formatters/reference_formatter_spec.rb
@@ -121,7 +121,7 @@ describe ReferenceFormatter do
     let(:reference) do
       create :nested_reference, nesting_reference: nestee_reference,
         author_names: [author_name], title: '*Atta* <i>and such</i>',
-        citation_year: '1874', pages_in: 'Pp. 32-45 in'
+        citation_year: '1874', pagination: 'Pp. 32-45 in'
     end
 
     describe "#plain_text" do
@@ -137,7 +137,7 @@ describe ReferenceFormatter do
           journal = create :journal, name: '<script>xss</script>'
           nesting_reference = create :article_reference, journal: journal, pagination: '<script>xss</script>',
             series_volume_issue: '<script>xss</script>'
-          create :nested_reference, nesting_reference: nesting_reference, pages_in: '<script>xss</script>'
+          create :nested_reference, nesting_reference: nesting_reference, pagination: '<script>xss</script>'
         end
 
         it "sanitizes them" do

--- a/spec/forms/reference_form_spec.rb
+++ b/spec/forms/reference_form_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe ReferenceForm do
   describe "#save" do
-    let(:original_params) { {} }
     let(:request_host) { 123 }
 
     describe "updating attributes" do
@@ -17,7 +16,7 @@ describe ReferenceForm do
       specify do
         expect(reference.bolton_key).to eq nil
 
-        described_class.new(reference, reference_params, original_params, request_host).save
+        described_class.new(reference, reference_params, request_host).save
 
         reference.reload
         expect(reference.bolton_key).to eq reference_params[:bolton_key]
@@ -36,13 +35,13 @@ describe ReferenceForm do
         end
 
         it "does not create new `AuthorName`s for existing authors" do
-          expect { described_class.new(reference, reference_params, original_params, request_host).save }.
+          expect { described_class.new(reference, reference_params, request_host).save }.
             to_not change { AuthorName.count }
         end
 
         it "does not create any versions for the reference" do
           with_versioning do
-            expect { described_class.new(reference, reference_params, original_params, request_host).save }.
+            expect { described_class.new(reference, reference_params, request_host).save }.
               to_not change { reference.versions.count }
           end
         end
@@ -59,7 +58,7 @@ describe ReferenceForm do
 
           it "creates a single version for the reference" do
             with_versioning do
-              expect { described_class.new(reference, reference_params, original_params, request_host).save }.
+              expect { described_class.new(reference, reference_params, request_host).save }.
                 to change { reference.versions.count }.by(1)
             end
           end
@@ -76,13 +75,13 @@ describe ReferenceForm do
           # TODO: We may want this.
           xit "creates a single version for the reference" do
             with_versioning do
-              expect { described_class.new(reference, reference_params, original_params, request_host).save }.
+              expect { described_class.new(reference, reference_params, request_host).save }.
                 to change { reference.versions.count }.by(1)
             end
           end
 
           it "updates `#author_names_string_cache`" do
-            expect { described_class.new(reference, reference_params, original_params, request_host).save }.
+            expect { described_class.new(reference, reference_params, request_host).save }.
               to change { reference.author_names_string_cache }.
               from('Batiatus, B.').to("Batiatus, B.; Glaber, G.")
           end
@@ -128,12 +127,12 @@ describe ReferenceForm do
       let!(:duplicate) { create :article_reference, author_names: original.author_names }
 
       it "allows a duplicate record to be saved" do
-        expect { described_class.new(duplicate, reference_params, original_params, request_host).save }.not_to raise_error
+        expect { described_class.new(duplicate, reference_params, request_host, ignore_duplicates: true).save }.not_to raise_error
       end
 
       it "checks possible duplication and add to errors, if any found" do
         expect(duplicate.errors).to be_empty
-        expect(described_class.new(duplicate, reference_params, original_params, request_host).save).to eq nil
+        expect(described_class.new(duplicate, reference_params, request_host).save).to eq nil
         expect(duplicate.errors[:possible_duplicate].first).to include "This may be a duplicate of Fisher"
       end
     end

--- a/spec/forms/reference_form_spec.rb
+++ b/spec/forms/reference_form_spec.rb
@@ -134,7 +134,7 @@ describe ReferenceForm do
       it "checks possible duplication and add to errors, if any found" do
         expect(duplicate.errors).to be_empty
         expect(described_class.new(duplicate, reference_params, original_params, request_host).save).to eq nil
-        expect(duplicate.errors[:base].first).to include "This may be a duplicate of Fisher"
+        expect(duplicate.errors[:possible_duplicate].first).to include "This may be a duplicate of Fisher"
       end
     end
   end

--- a/spec/forms/reference_form_spec.rb
+++ b/spec/forms/reference_form_spec.rb
@@ -39,6 +39,11 @@ describe ReferenceForm do
             to_not change { AuthorName.count }
         end
 
+        it "reuses existing `ReferenceAuthorName`s" do
+          expect { described_class.new(reference, reference_params, request_host).save }.
+            to_not change { reference.reload.reference_author_name_ids }
+        end
+
         it "does not create any versions for the reference" do
           with_versioning do
             expect { described_class.new(reference, reference_params, request_host).save }.

--- a/spec/models/references/nested_reference_spec.rb
+++ b/spec/models/references/nested_reference_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe NestedReference do
   it { is_expected.to validate_presence_of :year }
-  it { is_expected.to validate_presence_of :pages_in }
+  it { is_expected.to validate_presence_of :pagination }
   it { is_expected.to validate_presence_of(:nesting_reference).with_message("does not exist") }
 
   describe "validations" do

--- a/spec/services/authors/find_or_initialize_names_from_string_spec.rb
+++ b/spec/services/authors/find_or_initialize_names_from_string_spec.rb
@@ -1,14 +1,11 @@
 require 'rails_helper'
 
-describe Authors::FindOrCreateNamesFromString do
+describe Authors::FindOrInitializeNamesFromString do
   describe "#call" do
     describe 're-using and creating names' do
       let!(:bolton) { AuthorName.create!(name: 'Bolton, B.', author: Author.create!) }
 
-      it "finds or creates authors with names in the string" do
-        expect { described_class['Ward, P.S.; Bolton, B.'] }.
-          to change { AuthorName.count }.by(1)
-
+      it "finds or initializes authors with names in the string" do
         author_names = described_class['Ward, P.S.; Bolton, B.']
         expect(author_names.map(&:name)).to eq ['Ward, P.S.', 'Bolton, B.']
         expect(author_names.second.author).to eq bolton.author

--- a/spec/services/autocomplete/format_linkable_references_spec.rb
+++ b/spec/services/autocomplete/format_linkable_references_spec.rb
@@ -13,7 +13,7 @@ describe Autocomplete::FormatLinkableReferences do
               author: reference.author_names_string_with_suffix,
               year: reference.citation_year,
               title: "#{reference.title}.",
-              full_pagination: "[pagination: #{reference.pages_in} (#{reference.nesting_reference.pagination})]",
+              full_pagination: "[pagination: #{reference.pagination} (#{reference.nesting_reference.pagination})]",
               bolton_key: "[Bolton key: #{reference.bolton_key}]"
             }
           ]

--- a/spec/services/references/new_from_copy_spec.rb
+++ b/spec/services/references/new_from_copy_spec.rb
@@ -72,8 +72,8 @@ describe References::NewFromCopy do
 
         expect(copy).to be_a NestedReference
 
-        expect(copy.pages_in).to eq reference.pages_in
-        expect(copy.pages_in).to_not eq nil
+        expect(copy.pagination).to eq reference.pagination
+        expect(copy.pagination).to_not eq nil
         expect(copy.nesting_reference_id).to eq reference.nesting_reference_id
         expect(copy.nesting_reference_id).to_not eq nil
       end


### PR DESCRIPTION
Refactor and refactor-ish to make all `Reference`s use pagination in a consistent manner.

Changes:

- Use `pagination` for all types of references. We don't need to separate book/article pagination in the form, and we want use pagination for `UnknownReferences` too. That only leaves `NestedReference`s which are currently using `references.pages_in` but never `references.pagination`, so we might as well merge the columns.
- Other smaller tweaks.


I believe the article/book pagination was a special case due to how fields are conditionally hidden/shown in the reference form, but it makes the class responsible for saving references more complicated than what it needs to be.

More work is required here, but I think this is enough for this session.

Short version: Use the `pagination` column and pagination form field for all references, including nested references (which previously used the `pages_in` column and always kept the `pagination` column blank).