### PR TITLE
Validate reference author names

### DIFF
--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -29,6 +29,7 @@ class Reference < ApplicationRecord
 
   # TODO: Pull up `validates :year` once all `MissingReference` have been converted.
   validates :title, presence: true
+  validates :author_names, presence: true, unless: -> { is_a?(MissingReference) }
   validates :nesting_reference_id, absence: true, unless: -> { is_a?(NestedReference) }
   validates :doi, format: { with: /\A[^<>]*\z/ }
   validate :ensure_bolton_key_unique
@@ -116,7 +117,7 @@ class Reference < ApplicationRecord
   def authors_for_keey
     names = author_names.map(&:last_name)
     case names.size
-    when 0 then '[no authors]'
+    when 0 then '[no authors]' # TODO: This can still happen in the reference form.
     when 1 then names.first.to_s
     when 2 then "#{names.first} & #{names.second}"
     else        "#{names.first} <i>et al.</i>"

--- a/spec/controllers/my/recently_used_references_controller_spec.rb
+++ b/spec/controllers/my/recently_used_references_controller_spec.rb
@@ -18,7 +18,7 @@ describe My::RecentlyUsedReferencesController do
     end
 
     context 'when user has recently used references' do
-      let!(:reference) { create :reference }
+      let!(:reference) { create :article_reference }
 
       before do
         post :create, params: { id: reference.id }
@@ -26,24 +26,13 @@ describe My::RecentlyUsedReferencesController do
 
       it 'returns the references as a JSON array' do
         get :show
-        expect(json_response).to eq(
-          [
-            {
-              "id" => reference.id,
-              "author" => "",
-              "year" => reference.citation_year,
-              "title" => reference.title + '.',
-              "full_pagination" => "",
-              "bolton_key" => ""
-            }
-          ]
-        )
+        expect(json_response).to eq Autocomplete::FormatLinkableReferences[[reference]].map(&:stringify_keys)
       end
     end
   end
 
   describe 'POST create' do
-    let!(:reference) { create :reference }
+    let!(:reference) { create :article_reference }
 
     it "stores the reference in the user's session" do
       expect { post :create, params: { id: reference.id } }.
@@ -52,8 +41,8 @@ describe My::RecentlyUsedReferencesController do
     end
 
     describe 'adding multiple references' do
-      let!(:second) { create :reference }
-      let!(:third) { create :reference }
+      let!(:second) { create :article_reference }
+      let!(:third) { create :article_reference }
 
       it 'returns the the most recently used references first, unique only' do
         post :create, params: { id: reference.id }

--- a/spec/factories/references.rb
+++ b/spec/factories/references.rb
@@ -7,37 +7,38 @@ FactoryBot.define do
     sequence(:title) { |n| "Ants are my life#{n}" }
     sequence(:citation_year) { |n| "201#{n}d" }
 
-    after(:build) do |reference, evaluator|
-      if reference.author_names.blank? && evaluator.author_name
-        author_name = AuthorName.find_by(name: evaluator.author_name)
-        author_name ||= create :author_name, name: evaluator.author_name # TODO: Do not `.create`.
-        reference.author_names << author_name
+    after(:stub) do |reference, evaluator|
+      if evaluator.author_names.present?
+        reference.author_names = evaluator.author_names
       end
     end
 
-    after(:create) do |reference, evaluator|
-      if reference.author_names.blank? && evaluator.author_name
+    before(:create) do |reference, evaluator|
+      next if reference.is_a?(MissingReference)
+
+      if evaluator.author_names.present?
+        reference.author_names = evaluator.author_names
+      elsif evaluator.author_name
         author_name = AuthorName.find_by(name: evaluator.author_name)
         author_name ||= create :author_name, name: evaluator.author_name
         reference.author_names << author_name
+      else
+        reference.author_names = [create(:author_name)]
       end
     end
 
     factory :article_reference, class: 'ArticleReference' do
-      author_names { [create(:author_name)] }
       journal
       sequence(:series_volume_issue) { |n| n }
       sequence(:pagination) { |n| n }
     end
 
     factory :book_reference, class: 'BookReference' do
-      author_names { [create(:author_name)] }
       publisher
       sequence(:pagination) { |n| "#{n} pp." }
     end
 
     factory :unknown_reference, class: 'UnknownReference' do
-      author_names { [create(:author_name)] }
       citation { 'New York' }
     end
 
@@ -48,7 +49,6 @@ FactoryBot.define do
     end
 
     factory :nested_reference, class: 'NestedReference' do
-      author_names { [create(:author_name)] }
       pages_in { 'In: ' }
       nesting_reference { create :book_reference }
     end

--- a/spec/factories/references.rb
+++ b/spec/factories/references.rb
@@ -7,6 +7,14 @@ FactoryBot.define do
     sequence(:title) { |n| "Ants are my life#{n}" }
     sequence(:citation_year) { |n| "201#{n}d" }
 
+    after(:build) do |reference, evaluator|
+      if reference.author_names.blank? && evaluator.author_name
+        author_name = AuthorName.find_by(name: evaluator.author_name)
+        author_name ||= create :author_name, name: evaluator.author_name # TODO: Do not `.create`.
+        reference.author_names << author_name
+      end
+    end
+
     after(:create) do |reference, evaluator|
       if reference.author_names.blank? && evaluator.author_name
         author_name = AuthorName.find_by(name: evaluator.author_name)

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -15,7 +15,7 @@ describe Reference do
 
     describe '`bolton_key` uniqueness' do
       let!(:conflict) { create :article_reference, bolton_key: 'Batiatus 2000' }
-      let!(:duplicate) { build_stubbed :article_reference }
+      let!(:duplicate) { create :article_reference }
 
       specify do
         expect { duplicate.bolton_key = conflict.bolton_key }.
@@ -65,9 +65,9 @@ describe Reference do
 
     describe ".order_by_author_names_and_year" do
       it "sorts by author_name plus year plus letter" do
-        one = create :reference, author_name: 'Fisher', citation_year: '1910b'
-        two = create :reference, author_name: 'Wheeler', citation_year: '1874'
-        three = create :reference, author_name: 'Fisher', citation_year: '1910a'
+        one = create :article_reference, author_name: 'Fisher', citation_year: '1910b'
+        two = create :article_reference, author_name: 'Wheeler', citation_year: '1874'
+        three = create :article_reference, author_name: 'Fisher', citation_year: '1910a'
 
         expect(described_class.order_by_author_names_and_year).to eq [three, one, two]
       end

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -9,6 +9,7 @@ describe Reference do
   end
 
   describe 'validations' do
+    it { is_expected.to validate_presence_of :author_names }
     it { is_expected.to validate_presence_of :title }
     it { is_expected.to_not allow_values('<', '>').for(:doi) }
 
@@ -32,7 +33,7 @@ describe Reference do
   describe 'callbacks' do
     describe "changing `citation_year`" do
       context 'when `citation_year` contains a letter' do
-        let(:reference) { create :reference, citation_year: '1910a' }
+        let(:reference) { create :article_reference, citation_year: '1910a' }
 
         it "sets `year` to the stated year, if present" do
           expect { reference.update!(citation_year: '2010b') }.
@@ -41,7 +42,7 @@ describe Reference do
       end
 
       context 'when `citation_year` contains a bracketed year' do
-        let(:reference) { create :reference, citation_year: '1910a ["1958"]' }
+        let(:reference) { create :article_reference, citation_year: '1910a ["1958"]' }
 
         it "sets `year` to the stated year, if present" do
           expect { reference.update!(citation_year: '2010b ["2009"]') }.
@@ -207,7 +208,7 @@ describe Reference do
 
     context 'when no authors' do
       let(:reference) do
-        create :article_reference, author_names: [], citation_year: '1970a'
+        build_stubbed :article_reference, author_names: [], citation_year: '1970a'
       end
 
       specify { expect(reference.keey).to eq '[no authors], 1970a' }

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -203,7 +203,7 @@ describe Taxon do
   end
 
   it_behaves_like "a taxt column with cleanup", :headline_notes_taxt do
-    subject { build :family }
+    subject { create :family }
   end
 
   it_behaves_like "a taxt column with cleanup", :type_taxt do
@@ -213,11 +213,9 @@ describe Taxon do
   describe "workflow" do
     describe '`Workflow::ExternalTable`' do
       context "when taxon is created" do
-        let(:taxon) { build :family }
+        let!(:taxon) { create :family }
 
         it "creates a `TaxonState` with `review_status` 'waiting'" do
-          expect(taxon.taxon_state).to eq nil
-          taxon.save
           expect(taxon.taxon_state).not_to eq nil
           expect(taxon.reload.waiting?).to eq true
         end

--- a/spec/services/exporters/endnote/formatter_spec.rb
+++ b/spec/services/exporters/endnote/formatter_spec.rb
@@ -40,24 +40,6 @@ describe Exporters::Endnote::Formatter do
 )
   end
 
-  it "doesn't emit %A if there is no author" do
-    reference = create :book_reference,
-      author_names: [],
-      title: 'Ants Are My Life',
-      citation_year: '1933',
-      publisher: create(:publisher, name: 'Springer Verlag', place_name: 'Dresden'),
-      pagination: 'ix + 33pp.'
-    expect(described_class.format([reference])).to eq %(%0 Book
-%D 1933
-%T Ants Are My Life
-%C Dresden
-%I Springer Verlag
-%P ix + 33pp.
-%~ AntCat
-
-)
-  end
-
   it "formats a article reference correctly" do
     reference = create :article_reference,
       author_names: [create(:author_name, name: 'MacKay, W.')],

--- a/spec/services/markdowns/bolton_keys_to_ref_tags_spec.rb
+++ b/spec/services/markdowns/bolton_keys_to_ref_tags_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Markdowns::BoltonKeysToRefTags do
   describe "#call" do
-    let!(:latreille) { create :reference, bolton_key: "Latreille 1802c" }
+    let!(:latreille) { create :article_reference, bolton_key: "Latreille 1802c" }
 
     context "when content contains a matching reference" do
       specify { expect(described_class["Latreille, 1802c: 236;"]).to eq "{ref #{latreille.id}}: 236;" }
@@ -12,7 +12,7 @@ describe Markdowns::BoltonKeysToRefTags do
       end
 
       context "with ampersand in the key" do
-        let!(:agosti) { create :reference, bolton_key: "Agosti Wood 1987b" }
+        let!(:agosti) { create :article_reference, bolton_key: "Agosti Wood 1987b" }
 
         specify do
           expect(described_class["Agosti & Wood, 1987b: 236"]).to eq "{ref #{agosti.id}}: 236"
@@ -20,7 +20,7 @@ describe Markdowns::BoltonKeysToRefTags do
       end
 
       context "with 'et al.' in the key" do
-        let!(:agosti) { create :reference, bolton_key: "Agosti et al. 1987b" }
+        let!(:agosti) { create :article_reference, bolton_key: "Agosti et al. 1987b" }
 
         specify { expect(described_class["Agosti et al., 1987b: 236"]).to eq "{ref #{agosti.id}}: 236" }
       end
@@ -51,7 +51,7 @@ describe Markdowns::BoltonKeysToRefTags do
       end
 
       context "when both have matching Bolton keys on AntCat" do
-        let!(:fisher_et_al) { create :reference, bolton_key: "Fisher et al. 2002" }
+        let!(:fisher_et_al) { create :article_reference, bolton_key: "Fisher et al. 2002" }
 
         specify { expect(described_class[content]).to eq "{ref #{latreille.id}}: 236; {ref #{fisher_et_al.id}}: 37" }
       end

--- a/spec/services/references/search/fulltext_spec.rb
+++ b/spec/services/references/search/fulltext_spec.rb
@@ -4,10 +4,10 @@ describe References::Search::Fulltext, :search do
   describe "#call" do
     describe 'searching with `start_year`, `end_year` and `year`' do
       before do
-        create :reference, citation_year: '1994'
-        create :reference, citation_year: '1995'
-        create :reference, citation_year: '1996a'
-        create :reference, citation_year: '1998'
+        create :article_reference, citation_year: '1994'
+        create :article_reference, citation_year: '1995'
+        create :article_reference, citation_year: '1996a'
+        create :article_reference, citation_year: '1998'
         Sunspot.commit
       end
 
@@ -18,10 +18,10 @@ describe References::Search::Fulltext, :search do
     end
 
     describe "year" do
-      let!(:reference) { create :reference, citation_year: '2004' }
+      let!(:reference) { create :article_reference, citation_year: '2004' }
 
       before do
-        create :reference, citation_year: '2003'
+        create :article_reference, citation_year: '2003'
         Sunspot.commit
       end
 
@@ -31,9 +31,9 @@ describe References::Search::Fulltext, :search do
     end
 
     describe 'notes' do
-      let!(:with_public_notes) { create :reference, public_notes: 'public' }
-      let!(:with_editor_notes) { create :reference, editor_notes: 'editor' }
-      let!(:with_taxonomic_notes) { create :reference, taxonomic_notes: 'taxonomic' }
+      let!(:with_public_notes) { create :article_reference, public_notes: 'public' }
+      let!(:with_editor_notes) { create :article_reference, editor_notes: 'editor' }
+      let!(:with_taxonomic_notes) { create :article_reference, taxonomic_notes: 'taxonomic' }
 
       before do
         Sunspot.commit
@@ -139,7 +139,7 @@ describe References::Search::Fulltext, :search do
   describe "ignored characters" do
     context "when search query contains ').'" do
       let!(:title) { 'Tetramoriini (Hymenoptera Formicidae).' }
-      let!(:reference) { create :reference, title: title }
+      let!(:reference) { create :article_reference, title: title }
 
       before { Sunspot.commit }
 
@@ -178,7 +178,7 @@ describe References::Search::Fulltext, :search do
 
     describe "replacing some characters to make search work" do
       let!(:title) { '*Camponotus piceus* (Leach, 1825), decouverte Viroin-Hermeton' }
-      let!(:reference) { create :reference, title: title }
+      let!(:reference) { create :article_reference, title: title }
 
       it "handles this reference with asterixes and a hyphen" do
         Sunspot.commit

--- a/spec/services/taxa/search/advanced_search_spec.rb
+++ b/spec/services/taxa/search/advanced_search_spec.rb
@@ -34,7 +34,7 @@ describe Taxa::Search::AdvancedSearch do
       let!(:taxon) { create :subfamily }
 
       before do
-        reference = create :reference, citation_year: '1977'
+        reference = create :article_reference, citation_year: '1977'
         taxon.protonym.authorship.update!(reference: reference)
       end
 

--- a/spec/services/wikipedia/reference_exporter_spec.rb
+++ b/spec/services/wikipedia/reference_exporter_spec.rb
@@ -7,8 +7,8 @@ describe Wikipedia::ReferenceExporter do
 
     describe "when reference is an `ArticleReference`" do
       let(:reference) do
-        build_stubbed :article_reference, :with_doi, author_names: [batiatus], title: "*Formica* and Apples",
-          pagination: "7-14", year: "2000"
+        create :article_reference, :with_doi, author_names: [batiatus], title: "*Formica* and Apples",
+          pagination: "7-14", citation_year: "2000"
       end
 
       specify do
@@ -23,8 +23,8 @@ describe Wikipedia::ReferenceExporter do
 
     describe "when reference is a `BookReference`" do
       let(:reference) do
-        build_stubbed :book_reference, author_names: [batiatus, glaber], title: "*Formica* and Apples",
-          pagination: "7-14", year: "2000"
+        create :book_reference, author_names: [batiatus, glaber], title: "*Formica* and Apples",
+          pagination: "7-14", citation_year: "2000"
       end
 
       specify do
@@ -39,7 +39,7 @@ describe Wikipedia::ReferenceExporter do
     end
 
     describe "name tag" do
-      let(:reference) { build_stubbed :article_reference, author_names: author_names, year: "2016" }
+      let(:reference) { create :article_reference, author_names: author_names, citation_year: "2016" }
 
       context "when reference has one author" do
         let(:author_names) { [batiatus] }


### PR DESCRIPTION
Now only `MissingReference`s are allowed to not have any authors associated with the reference.