### PR TITLE
Reorder reference sections

### DIFF
--- a/app/assets/javascripts/controllers/taxa/reorder_history_items.coffee
+++ b/app/assets/javascripts/controllers/taxa/reorder_history_items.coffee
@@ -1,3 +1,5 @@
+# TODO: Copy-pasted into `reorder_reference_sections.coffee`.
+
 # Global variables to make it easy to disable other form buttons
 # when interacting with a subform.
 

--- a/app/assets/javascripts/controllers/taxa/reorder_history_items.coffee
+++ b/app/assets/javascripts/controllers/taxa/reorder_history_items.coffee
@@ -11,8 +11,8 @@ $ ->
   setupReorderButton()
 
 # These elements are from the view.
-SORTABLE =       ".history-items"
-SORTABLE_ITEM =  ".history-item"
+SORTABLE =      ".history-items"
+SORTABLE_ITEM = ".history-item"
 
 # Random class to check if the element already is sortable, because jQuery cannot reliably do it.
 IS_SORTABLE = "is-sortable-made-up-class"

--- a/app/assets/javascripts/controllers/taxa/reorder_reference_sections.coffee
+++ b/app/assets/javascripts/controllers/taxa/reorder_reference_sections.coffee
@@ -1,0 +1,89 @@
+# TODO: Copy-pasted from `reorder_history_items.coffee`.
+
+# Global variables to make it easy to disable other form buttons
+# when interacting with a subform.
+
+AntCat.BUTTONS ||= {}
+
+AntCat.BUTTONS.ADD_REFERENCE_SECTION =      "#add-reference-section-button"
+AntCat.BUTTONS.REORDER_REFERENCE_SECTIONS = "#start-reordering-reference-sections"
+AntCat.BUTTONS.SAVE_TAXON_FORM =            "#save-taxon-form"
+
+$ ->
+  setupReorderButton()
+
+# These elements are from the view.
+SORTABLE =      ".reference-sections"
+SORTABLE_ITEM = ".reference-section"
+
+# Random class to check if the element already is sortable, because jQuery cannot reliably do it.
+IS_SORTABLE = "is-sortable-made-up-class"
+
+setupReorderButton = ->
+  $(AntCat.BUTTONS.REORDER_REFERENCE_SECTIONS).on "click", ->
+    if $(SORTABLE).hasClass IS_SORTABLE
+      disableReordering()
+    else
+      startReordering()
+
+startReordering = ->
+  $(AntCat.BUTTONS.REORDER_REFERENCE_SECTIONS).disableButton()
+  $(AntCat.BUTTONS.ADD_REFERENCE_SECTION).disableButton()
+  $(AntCat.BUTTONS.SAVE_TAXON_FORM).disable()
+
+  do makeSortable = ->
+    $(SORTABLE).addClass IS_SORTABLE
+    $(SORTABLE).sortable
+      items: SORTABLE_ITEM
+      cursor: "move"
+      opacity: 0.7
+      disabled: false
+      start: -> $("#save-reordered-reference-sections").removeClass "disabled"
+
+  do createReorderingControls = ->
+    $(SORTABLE).prepend $ """
+      <div id="reorder-reference-sections-controls" class="callout center-text">
+        Drag and drop reference sections to reorder them.
+        <a id="save-reordered-reference-sections" class="btn-saves btn-tiny disabled button">
+          Save new order
+        </a>
+        <a id="cancel-reference-section-reordering" class="btn-nodanger btn-tiny">Cancel</a>
+      </div>"""
+
+    $("#save-reordered-reference-sections").on "click", -> saveNewOrder()
+
+    $("#cancel-reference-section-reordering").on "click", ->
+      do restorePreviousOrder = -> $(SORTABLE).sortable "cancel"
+      disableReordering()
+
+disableReordering = ->
+  $(SORTABLE).removeClass IS_SORTABLE
+  $(SORTABLE).sortable "disable"
+
+  do destroyReorderingControls = -> $("#reorder-reference-sections-controls").remove()
+
+  $(AntCat.BUTTONS.REORDER_REFERENCE_SECTIONS).enableButton()
+  $(AntCat.BUTTONS.ADD_REFERENCE_SECTION).enableButton()
+  $(AntCat.BUTTONS.SAVE_TAXON_FORM).undisable()
+
+saveNewOrder = ->
+  taxonId = $(SORTABLE).data "taxon-id"
+
+  $.ajax
+    type: "POST"
+    url: "/taxa/#{taxonId}/reorder_reference_sections"
+    dataType: 'json'
+    data: $(SORTABLE).sortable "serialize"
+    success: ->
+      $(SORTABLE).sortable "refreshPositions"
+      disableReordering()
+    error: (error) ->
+      # TODO: Create modal for this and other errors.
+      pleaseSee = "Please check the feed and see if there is a 'User reordered the reference
+        sections...' and let us know via the Feedback link or create an issue on GitHub."
+
+      alert """Sorry, something went wrong.
+
+            Error: '#{error.responseText}'
+
+            #{pleaseSee}"""

--- a/app/controllers/taxa/reorder_history_items_controller.rb
+++ b/app/controllers/taxa/reorder_history_items_controller.rb
@@ -1,3 +1,5 @@
+# TODO: Copy-pasted into `Taxa::ReorderReferenceSectionsController`.
+
 module Taxa
   class ReorderHistoryItemsController < ApplicationController
     before_action :ensure_user_is_editor

--- a/app/controllers/taxa/reorder_history_items_controller.rb
+++ b/app/controllers/taxa/reorder_history_items_controller.rb
@@ -4,6 +4,7 @@ module Taxa
     before_action :set_taxon
 
     def create
+      # NOTE: "taxon_history_item_ids" would be better, but `params[:taxon_history_item]` is what jQuery sends it as.
       if Taxa::Operations::ReorderHistoryItems[@taxon, params[:taxon_history_item]]
         @taxon.create_activity :reorder_taxon_history_items, current_user
         render json: { success: true }

--- a/app/controllers/taxa/reorder_reference_sections_controller.rb
+++ b/app/controllers/taxa/reorder_reference_sections_controller.rb
@@ -1,0 +1,24 @@
+# TODO: Copy-pasted into `Taxa::ReorderHistoryItemsController`.
+
+module Taxa
+  class ReorderReferenceSectionsController < ApplicationController
+    before_action :ensure_user_is_editor
+    before_action :set_taxon
+
+    def create
+      # NOTE: "reference_section_ids" would be better, but `params[:reference_section]` is what jQuery sends it as.
+      if Taxa::Operations::ReorderReferenceSections[@taxon, params[:reference_section]]
+        @taxon.create_activity :reorder_reference_sections, current_user
+        render json: { success: true }
+      else
+        render json: @taxon.errors, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+      def set_taxon
+        @taxon = Taxon.find(params[:taxa_id])
+      end
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -28,6 +28,7 @@ class Activity < ApplicationRecord
     reopen_feedback
     reopen_issue
     reorder_taxon_history_items
+    reorder_reference_sections
     replace_missing_reference
     restart_reviewing
     start_reviewing

--- a/app/services/taxa/operations/reorder_history_items.rb
+++ b/app/services/taxa/operations/reorder_history_items.rb
@@ -23,8 +23,8 @@ module Taxa
 
           taxon.transaction do
             reordered_ids.each_with_index do |id, index|
-              item = TaxonHistoryItem.find(id)
-              item.update!(position: (index + 1))
+              history_item = TaxonHistoryItem.find(id)
+              history_item.update!(position: (index + 1))
             end
           end
 

--- a/app/services/taxa/operations/reorder_reference_sections.rb
+++ b/app/services/taxa/operations/reorder_reference_sections.rb
@@ -1,8 +1,8 @@
-# TODO: Copy-pasted into `Taxa::Operations::ReorderReferenceSections`.
+# TODO: Copy-pasted from `Taxa::Operations::ReorderHistoryItems`.
 
 module Taxa
   module Operations
-    class ReorderHistoryItems
+    class ReorderReferenceSections
       include Service
 
       def initialize taxon, reordered_ids
@@ -11,41 +11,41 @@ module Taxa
       end
 
       def call
-        reorder_history_items reordered_ids
+        reorder_reference_sections reordered_ids
       end
 
       private
 
         attr_reader :taxon, :reordered_ids
 
-        delegate :history_items, :errors, to: :taxon
+        delegate :reference_sections, :errors, to: :taxon
 
-        def reorder_history_items reordered_ids
+        def reorder_reference_sections reordered_ids
           return false unless reordered_ids_valid? reordered_ids
 
           taxon.transaction do
             reordered_ids.each_with_index do |id, index|
-              history_item = TaxonHistoryItem.find(id)
-              history_item.update!(position: (index + 1))
+              reference_section = ReferenceSection.find(id)
+              reference_section.update!(position: (index + 1))
             end
           end
 
           true
         rescue ActiveRecord::RecordInvalid
-          errors.add :history_items, "History items are not valid, please fix them first"
+          errors.add :reference_sections, "Reference sections are not valid, please fix them first"
           false
         end
 
         def reordered_ids_valid? reordered_ids_strings
-          current_ids = history_items.pluck :id
+          current_ids = reference_sections.pluck(:id)
           reordered_ids = reordered_ids_strings.map(&:to_i)
 
           if current_ids == reordered_ids
-            errors.add :history_items, "History items are already ordered like this"
+            errors.add :reference_sections, "Reference sections are already ordered like this"
           end
 
           unless current_ids.sort == reordered_ids.sort
-            errors.add :history_items, <<-ERROR.squish
+            errors.add :reference_sections, <<-ERROR.squish
               Reordered IDs '#{reordered_ids}' doesn't match current IDs #{current_ids}.
             ERROR
           end

--- a/app/views/activities/templates/actions/_reorder_reference_sections.haml
+++ b/app/views/activities/templates/actions/_reorder_reference_sections.haml
@@ -1,0 +1,2 @@
+reordered the reference sections of
+=taxon_link_or_deleted_string activity.trackable_id

--- a/app/views/taxa/_not_really_form/_history_items_section.haml
+++ b/app/views/taxa/_not_really_form/_history_items_section.haml
@@ -2,6 +2,7 @@
   %h5.callout-header
     History
     .right
+      -# NOTE: CSS classes "button submit" are for disabling the "Add" button while reordering.
       =link_to 'Add', new_taxa_taxon_history_item_path(taxon), id: 'taxt-editor-add-history-item-button', title: "Note: New items are added on a different page. Please save your changes first if you would like to keep them.", class: 'button submit btn-normal btn-tiny jquery-tooltip'
       %a#start-reordering-history-items.btn-nodanger.btn-tiny.button Reorder
   .history-items{data: {taxon_id: taxon.id}}

--- a/app/views/taxa/_not_really_form/_history_items_section.haml
+++ b/app/views/taxa/_not_really_form/_history_items_section.haml
@@ -1,3 +1,5 @@
+-# TODO: Some copy-paste into `_reference_sections.haml`.
+
 .history-items-section.callout
   %h5.callout-header
     History

--- a/app/views/taxa/_not_really_form/_references_section.haml
+++ b/app/views/taxa/_not_really_form/_references_section.haml
@@ -1,10 +1,15 @@
+-# TODO: Some copy-paste from `_history_items_section.haml`.
+
 -unless taxon.is_a? SpeciesGroupTaxon
   .references-section.callout
     %h5.callout-header
       References
       .right
-        =link_to 'Add', new_taxa_reference_section_path(taxon), id: 'add-reference-section-button', title: "Note: New items are added on a different page. Please save your changes first if you would like to keep them.", class: 'btn-normal btn-tiny jquery-tooltip'
-
-    .reference-sections
+        -# NOTE: CSS classes "button submit" are for disabling the "Add" button while reordering.
+        =link_to 'Add', new_taxa_reference_section_path(taxon), id: 'add-reference-section-button', title: "Note: New items are added on a different page. Please save your changes first if you would like to keep them.", class: 'button submit btn-normal btn-tiny jquery-tooltip'
+        %a#start-reordering-reference-sections.btn-nodanger.btn-tiny.button Reorder
+    .reference-sections{data: {taxon_id: taxon.id}}
       -taxon.reference_sections.each do |reference_section|
-        =render 'reference_sections/taxt_editor_template', reference_section: reference_section
+        -# `#reference_section_123` is used for reordering items.
+        .reference-section{id: "reference_section_#{reference_section.id}"}
+          =render 'reference_sections/taxt_editor_template', reference_section: reference_section

--- a/app/views/taxa/edit.haml
+++ b/app/views/taxa/edit.haml
@@ -2,7 +2,7 @@
 -breadcrumb :edit_taxon, @taxon
 
 -content_for :head do
-  =javascript_include_tag 'controllers/taxa/reorder_history_items'
+  =javascript_include_tag 'controllers/taxa/reorder_history_items', 'controllers/taxa/reorder_reference_sections'
 
 =render 'form', taxon: @taxon, default_name_string: nil
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -36,6 +36,7 @@ Rails.application.config.assets.precompile += %w[
   controllers/taxa/form/locality_autocompletion.js
   controllers/taxa/move_items/select_checkboxes.js
   controllers/taxa/reorder_history_items.js
+  controllers/taxa/reorder_reference_sections.js
 ]
 
 Rails.application.config.assets.precompile += %w[foundation_and_overrides.css]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ Rails.application.routes.draw do
       resource :move_items, only: [:new, :show, :create]
       resource :set_subgenus, only: [:show, :create, :destroy]
       resource :reorder_history_items, only: [:create]
+      resource :reorder_reference_sections, only: [:create]
     end
   end
 

--- a/spec/controllers/taxa/reorder_reference_sections_controller_spec.rb
+++ b/spec/controllers/taxa/reorder_reference_sections_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe Taxa::ReorderReferenceSectionsController do
+  describe "forbidden actions" do
+    context "when signed in as a user" do
+      before { sign_in create(:user) }
+
+      specify { expect(post(:create, params: { taxa_id: 1 })).to have_http_status :forbidden }
+    end
+  end
+
+  describe "POST create" do
+    let(:taxon) { create :family }
+    let(:reordered_ids) { [second.id.to_s, first.id.to_s] }
+    let!(:first) { taxon.reference_sections.create! }
+    let!(:second) { taxon.reference_sections.create! }
+
+    before { sign_in create(:user, :editor) }
+
+    it "calls `Taxa::Operations::ReorderReferenceSections`" do
+      expect(Taxa::Operations::ReorderReferenceSections).to receive(:new).with(taxon, reordered_ids).and_call_original
+      post :create, params: { taxa_id: taxon.id, reference_section: reordered_ids }
+    end
+
+    it "reorders the reference sections" do
+      expect { post :create, params: { taxa_id: taxon.id, reference_section: reordered_ids } }.
+        to change { taxon.reference_sections.pluck(:id) }.to([second.id, first.id])
+    end
+
+    it 'creates an activity' do
+      expect { post(:create, params: { taxa_id: taxon.id, reference_section: reordered_ids }) }.
+        to change { Activity.where(action: :reorder_reference_sections).count }.by(1)
+
+      activity = Activity.last
+      expect(activity.trackable).to eq taxon
+    end
+  end
+end

--- a/spec/services/taxa/operations/reorder_reference_sections_spec.rb
+++ b/spec/services/taxa/operations/reorder_reference_sections_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe Taxa::Operations::ReorderReferenceSections do
+  describe "#call" do
+    let(:taxon) { create :family }
+    let(:original_order) { item_ids taxon }
+    let!(:first) { taxon.reference_sections.create! }
+    let!(:second) { taxon.reference_sections.create! }
+    let!(:third) { taxon.reference_sections.create! }
+
+    def item_ids taxon
+      taxon.reference_sections.pluck(:id)
+    end
+
+    context "when valid and different" do
+      let(:reordered_ids) { [second.id, third.id, first.id] }
+
+      it 'returns true' do
+        expect(described_class[taxon, reordered_ids]).to eq true
+      end
+
+      it "updates the positions" do
+        expect { described_class[taxon, reordered_ids] }.
+          to change { item_ids(taxon) }.from(original_order).to(reordered_ids)
+      end
+    end
+
+    context "when valid but not different" do
+      let(:reordered_ids) { [first.id, second.id, third.id] }
+
+      it "doesn't update the positions" do
+        expect { described_class[taxon, reordered_ids] }.
+          to_not change { item_ids(taxon) }.from(original_order)
+      end
+
+      it 'adds an error to the taxon' do
+        expect(described_class[taxon, reordered_ids]).to eq false
+        expect(taxon.errors.messages[:reference_sections]).to include(/already ordered like this/)
+      end
+    end
+
+    context "when reordered ids are invalid" do
+      let(:reordered_ids) { [second.id, third.id, 9999999] }
+
+      it "doesn't update the positions" do
+        expect { described_class[taxon, reordered_ids] }.
+          to_not change { item_ids(taxon) }.from(original_order)
+      end
+
+      it 'adds an error to the taxon' do
+        expect(described_class[taxon, reordered_ids]).to eq false
+        expect(taxon.errors.messages[:reference_sections]).to include(/doesn't match current IDs/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Copy-pasta of the code for reordering history items because a) it was very
easy, b) we don't care too much about this code since it will be
replaced once we migrate to more relational reference sections.