### PR TITLE
Tweak ReferenceDocument

### DIFF
--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -95,7 +95,7 @@ class ReferencesController < ApplicationController
     end
 
     def reference_form
-      ReferenceForm.new(@reference, reference_params, request.host, ignore_duplicates: params[:ignore_duplicates].present?)
+      ReferenceForm.new(@reference, reference_params, ignore_duplicates: params[:ignore_duplicates].present?)
     end
 
     def set_reference_type

--- a/app/database_scripts/database_scripts/reference_documents_with_weird_actual_urls.rb
+++ b/app/database_scripts/database_scripts/reference_documents_with_weird_actual_urls.rb
@@ -2,7 +2,7 @@ module DatabaseScripts
   class ReferenceDocumentsWithWeirdActualUrls < DatabaseScript
     def results
       broken_ids = ReferenceDocument.where.not(file_file_name: ['', nil]).to_a.reject do |document|
-        document.url == document.__send__(:url_via_file_file_name)
+        document.url.blank? || (document.url == document.__send__(:url_via_file_file_name))
       end.map(&:id)
 
       ReferenceDocument.where(id: broken_ids)
@@ -10,11 +10,12 @@ module DatabaseScripts
 
     def render
       as_table do |t|
-        t.header 'Document ID', 'Created at', 'Kinda same?', 'Generated URL / Filename / URL'
+        t.header 'Document ID', 'Created at', 'Reference', 'Kinda same?', 'Generated URL / Filename / URL'
         t.rows do |reference_document|
           [
             reference_document.id,
             reference_document.created_at,
+            (reference_document.reference ? reference_document.reference.decorate.link_to_reference : '(none)'),
             (kinda_same?(reference_document) ? 'Yes' : 'No'),
             <<~STR
               #{link_it reference_document.__send__(:url_via_file_file_name)}<br>

--- a/app/database_scripts/database_scripts/reference_documents_with_weird_actual_urls.rb
+++ b/app/database_scripts/database_scripts/reference_documents_with_weird_actual_urls.rb
@@ -2,7 +2,7 @@ module DatabaseScripts
   class ReferenceDocumentsWithWeirdActualUrls < DatabaseScript
     def results
       broken_ids = ReferenceDocument.where.not(file_file_name: ['', nil]).to_a.reject do |document|
-        document.url == document.url_via_file_file_name
+        document.url == document.__send__(:url_via_file_file_name)
       end.map(&:id)
 
       ReferenceDocument.where(id: broken_ids)
@@ -17,7 +17,7 @@ module DatabaseScripts
             reference_document.created_at,
             (kinda_same?(reference_document) ? 'Yes' : 'No'),
             <<~STR
-              #{link_it reference_document.url_via_file_file_name}<br>
+              #{link_it reference_document.__send__(:url_via_file_file_name)}<br>
               #{reference_document.file_file_name}<br>
               #{link_it reference_document.url}
             STR
@@ -33,7 +33,7 @@ module DatabaseScripts
       end
 
       def kinda_same? reference_document
-        normalize_url(reference_document.url_via_file_file_name) ==
+        normalize_url(reference_document.__send__(:url_via_file_file_name)) ==
           normalize_url(reference_document.url)
       end
 

--- a/app/decorators/reference_decorator.rb
+++ b/app/decorators/reference_decorator.rb
@@ -33,7 +33,7 @@ class ReferenceDecorator < Draper::Decorator
 
   def pdf_link
     return unless reference.downloadable?
-    helpers.pdf_link_to 'PDF', reference.url
+    helpers.pdf_link_to 'PDF', reference.routed_url
   end
 
   def format_review_state

--- a/app/decorators/reference_decorator/nested_reference_decorator.rb
+++ b/app/decorators/reference_decorator/nested_reference_decorator.rb
@@ -4,13 +4,13 @@ class NestedReferenceDecorator < ReferenceDecorator
   # Fall back to nesting reference's PDF is nestee does not have one.
   def pdf_link
     return nesting_reference_pdf_link unless reference.downloadable?
-    helpers.external_link_to 'PDF', reference.url
+    helpers.external_link_to 'PDF', reference.routed_url
   end
 
   private
 
     def nesting_reference_pdf_link
       return unless nesting_reference.downloadable?
-      helpers.external_link_to 'PDF', nesting_reference.url
+      helpers.external_link_to 'PDF', nesting_reference.routed_url
     end
 end

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -45,8 +45,12 @@ class ReferenceForm
 
     def clear_document_params_if_necessary
       return unless params[:document_attributes]
-      return if params[:document_attributes][:url].blank?
-      params[:document_attributes][:id] = nil
+
+      # TODO: Make sure documents have either a `file_file_name` or a `url`.
+      # We cannot conditionally clear them before fixing current `ReferenceDocument`s.
+      if params[:document_attributes][:file].present?
+        params[:document_attributes][:url] = "" # Probably nil, but most are blank string right now.
+      end
     end
 
     def parse_author_names_string

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -1,10 +1,9 @@
 class ReferenceForm
   POSSIBLE_DUPLICATE_ERROR_KEY = :possible_duplicate # HACK: To get rid of other hack.
 
-  def initialize reference, params, request_host, ignore_duplicates: false
+  def initialize reference, params, ignore_duplicates: false
     @reference = reference
     @params = params
-    @request_host = request_host
     @ignore_duplicates = ignore_duplicates
   end
 
@@ -14,7 +13,7 @@ class ReferenceForm
 
   private
 
-    attr_reader :reference, :params, :request_host, :ignore_duplicates
+    attr_reader :reference, :params, :ignore_duplicates
 
     def save_reference
       Reference.transaction do
@@ -37,7 +36,6 @@ class ReferenceForm
         end
 
         reference.save!
-        set_document_host
 
         return true
       end
@@ -103,10 +101,5 @@ class ReferenceForm
         To save, click "Save".
       MSG
       true
-    end
-
-    def set_document_host
-      return unless reference.document
-      reference.document.host = request_host
     end
 end

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -44,7 +44,7 @@ class Reference < ApplicationRecord
   scope :unreviewed, -> { where.not(review_state: "reviewed") }
 
   accepts_nested_attributes_for :document, reject_if: :all_blank
-  delegate :url, :downloadable?, to: :document, allow_nil: true
+  delegate :routed_url, :downloadable?, to: :document, allow_nil: true
   has_paper_trail
   strip_attributes only: [
     :editor_notes, :public_notes, :taxonomic_notes, :title,

--- a/app/models/reference_document.rb
+++ b/app/models/reference_document.rb
@@ -38,11 +38,17 @@ class ReferenceDocument < ApplicationRecord
   end
 
   def downloadable?
+    return true if hosted_by_us?
     url.present? && !hosted_by_antbase? && !hosted_by_hol?
   end
 
   def actual_url
     hosted_by_us? ? s3_url : url
+  end
+
+  # TODO: Rename `reference_documents.url` --> `reference_documents.external_url`.
+  def routed_url
+    hosted_by_us? ? url_via_file_file_name : url
   end
 
   private

--- a/app/models/reference_document.rb
+++ b/app/models/reference_document.rb
@@ -4,9 +4,7 @@
 class ReferenceDocument < ApplicationRecord
   belongs_to :reference
 
-  validate :check_url
-
-  before_validation :add_protocol_to_url
+  validate :check_url, :ensure_url_has_protocol
 
   has_attached_file :file,
     url: ':s3_domain_url',
@@ -80,9 +78,10 @@ class ReferenceDocument < ApplicationRecord
       file_file_name.present?
     end
 
-    # TODO: This does not take into account HTTPS. We can probably stop doing it.
-    def add_protocol_to_url
-      self.url = "http://" + url if url.present? && url !~ %r{^http://}
+    def ensure_url_has_protocol
+      return if url.blank?
+      return if url.match?(%r{^https?://})
+      errors.add :url, 'must start with http:// or https://'
     end
 
     def s3_url

--- a/app/models/reference_document.rb
+++ b/app/models/reference_document.rb
@@ -23,16 +23,6 @@ class ReferenceDocument < ApplicationRecord
     true
   end
 
-  # TODO: See if we need this (and a lot of other things in this class).
-  # TODO: `host` is sometimes "http://antcat.org" and sometimes "http://www.antcat.org".
-  # TODO: HTTPS adds another 2 variations.
-  def host= host
-    return unless hosted_by_us?
-    # TODO: Investigate `Rails/SkipsModelValidations`.
-    update_attribute :url, "http://#{host}/documents/#{id}/#{file_file_name}" # rubocop:disable Rails/SkipsModelValidations
-  end
-
-  # TODO: Dynamically generate URL instead of setting host in `#host=`.
   def url_via_file_file_name
     "http://antcat.org/documents/#{id}/#{file_file_name}"
   end

--- a/app/services/exporters/endnote/formatter.rb
+++ b/app/services/exporters/endnote/formatter.rb
@@ -30,7 +30,7 @@ module Exporters
         add_contents
         add 'Z', public_notes
         add 'K', taxonomic_notes
-        add 'U', url
+        add 'U', routed_url
         add '~', 'AntCat'
         string.join("\n") + "\n"
       end
@@ -40,7 +40,7 @@ module Exporters
         attr_reader :reference
         attr_accessor :string
 
-        delegate :author_names, :year, :title, :public_notes, :taxonomic_notes, :url, to: :reference
+        delegate :author_names, :year, :title, :public_notes, :taxonomic_notes, :routed_url, to: :reference
 
         def add tag, value
           string << "%#{tag} #{value.to_s.gsub(/[|*]/, '')}" if value.present?

--- a/app/services/wikipedia/reference_exporter.rb
+++ b/app/services/wikipedia/reference_exporter.rb
@@ -23,7 +23,7 @@ module Wikipedia
       attr_reader :reference
 
       def url
-        reference.url if reference.downloadable?
+        reference.routed_url if reference.downloadable?
       end
 
       def pages

--- a/app/views/references/_form.haml
+++ b/app/views/references/_form.haml
@@ -133,6 +133,21 @@
       Reference document
       =db_tooltip_icon "references.pdf.upload", scope: :references
     =f.fields_for :document, (reference.document || ReferenceDocument.new) do |document_form|
+      -if document_form.object.file_file_name.present? && document_form.object.url.present?
+        .row.margin-bottom
+          .medium-6.columns.end
+            -if document_form.object.url == document_form.object.__send__(:url_via_file_file_name)
+              .callout.success
+                %p
+                  This reference has both an uploaded PDF and an URL. The hardcoded URL is the same as
+                  the dynamically generated link, so this notice can be ignored. The plan is to
+                  blank the URL by script.
+            -else
+              .callout.alert
+                %p
+                  This reference has both an uploaded PDF and an URL. The hardcoded URL is not the same
+                  as the dynamically generated link. The URL will be ignored when displaying
+                  this reference on the site, since uploaded files have higher priority.
       .row
         .medium-3.columns
           =document_form.file_field :file

--- a/app/views/references/_form.haml
+++ b/app/views/references/_form.haml
@@ -150,6 +150,11 @@
       .row
         .medium-12.columns
           =succeed ":" do
+            %code reference_documents.id
+          =document_form.object.id || '(none)'
+      .row
+        .medium-12.columns
+          =succeed ":" do
             %code file_file_name
           -if document_form.object.file_file_name.present?
             =document_form.object.file_file_name

--- a/app/views/references/_form.haml
+++ b/app/views/references/_form.haml
@@ -147,6 +147,14 @@
             Source URL
             =db_tooltip_icon "references.source.url", scope: :references
           =document_form.text_field :url
+      .row
+        .medium-12.columns
+          =succeed ":" do
+            %code file_file_name
+          -if document_form.object.file_file_name.present?
+            =document_form.object.file_file_name
+          -else
+            (none)
 
   .row
     .medium-3.columns

--- a/app/views/references/_form.haml
+++ b/app/views/references/_form.haml
@@ -83,7 +83,7 @@
                 =db_tooltip_icon "references.journal_name", scope: :references
               =f.text_field :journal_name, value: reference.journal_name
 
-            .medium-3.columns
+            .medium-3.columns.end
               =f.label :reference_series_volume_issue do
                 Series volume issue
                 =db_tooltip_icon "references.series_volume_issue", scope: :references
@@ -91,7 +91,7 @@
 
         #tabs-book.tabs-panel{class: reference_tab_active?(reference, BookReference)}
           .row
-            .medium-3.columns
+            .medium-3.columns.end
               =f.label :reference_publisher_string do
                 Publisher
                 =db_tooltip_icon "references.publisher", scope: :references
@@ -106,8 +106,10 @@
               =f.text_field :nesting_reference_id
 
         #tabs-unknown.tabs-panel{class: reference_tab_active?(reference, UnknownReference)}
-          =f.label :reference_citation, 'Citation'
-          =f.text_area :citation, rows: 2
+          .row
+            .medium-12.columns
+              =f.label :reference_citation, 'Citation'
+              =f.text_area :citation, rows: 2
 
   .row
     .medium-4.columns

--- a/features/references/search_references.feature
+++ b/features/references/search_references.feature
@@ -32,7 +32,7 @@ Feature: Searching references
     And I should not see the following autocomplete suggestions:
       | Fisher's Ants |
 
-  # TODO: Skipped because flaky.
+  # TODO: Skipped because flaky. Something with select2.
   @skip @javascript @search
   Scenario: Search using autocomplete keywords
     When I fill in "reference_q" with "author:fish" within the desktop menu

--- a/features/references/search_references.feature
+++ b/features/references/search_references.feature
@@ -32,7 +32,8 @@ Feature: Searching references
     And I should not see the following autocomplete suggestions:
       | Fisher's Ants |
 
-  @javascript @search
+  # TODO: Skipped because flaky.
+  @skip @javascript @search
   Scenario: Search using autocomplete keywords
     When I fill in "reference_q" with "author:fish" within the desktop menu
     Then I should see the following autocomplete suggestions:

--- a/features/step_definitions/reference_steps.rb
+++ b/features/step_definitions/reference_steps.rb
@@ -67,8 +67,8 @@ Then("I should see a PDF link") do
 end
 
 When("I fill in {string} with a URL to a document that exists") do |field_name|
-  stub_request :any, "google.com/foo"
-  step %(I fill in "#{field_name}" with "google\.com/foo")
+  stub_request :any, "http://google.com/foo"
+  step %(I fill in "#{field_name}" with "http://google\.com/foo")
 end
 
 Given("the default reference is {string}") do |keey|

--- a/features/widgets/taxon_selector.feature
+++ b/features/widgets/taxon_selector.feature
@@ -14,6 +14,9 @@ Feature: Taxon selector
     When I press "Save"
     Then I should see "Eciton" within the header
 
+  # TODO: Test mysteriously broke. Something with select2.
+  # See also features/references/search_references.feature
+  @skip
   Scenario: Clearing a taxon field
     When I go to the edit page for "Atta"
     And I select "homonym" from "taxon_status"

--- a/spec/decorators/reference_decorator_spec.rb
+++ b/spec/decorators/reference_decorator_spec.rb
@@ -28,7 +28,7 @@ describe ReferenceDecorator do
 
     before do
       allow(reference).to receive(:downloadable?).and_return true
-      allow(reference).to receive(:url).and_return 'example.com'
+      allow(reference).to receive(:routed_url).and_return 'example.com'
     end
 
     it "creates a link" do

--- a/spec/forms/reference_form_spec.rb
+++ b/spec/forms/reference_form_spec.rb
@@ -146,8 +146,9 @@ describe ReferenceForm do
       let(:params) do
         {
           author_names_string: "Batiatus, B.",
+          title: "Should be updated",
           document_attributes: {
-            url: "localhost/documents/#{reference.document.id}/123.pdf",
+            url: "http://localhost/documents/#{reference.document.id}/123.pdf",
             id: reference.document.id
           }
         }
@@ -156,11 +157,11 @@ describe ReferenceForm do
       context 'when reference has a document' do
         let!(:reference) { create :unknown_reference, :with_document }
 
-        # TODO: Do not create new a `ReferenceDocument`s.
-        xit 'does not create a new `ReferenceDocument`s' do
+        it 'does not create a new `ReferenceDocument`s' do
           expect(ReferenceDocument.count).to eq 1
           expect { described_class.new(reference, params).save }.
-            to_not change { ReferenceDocument.count }
+            to change { reference.reload.title }.to(params[:title])
+          expect(ReferenceDocument.count).to eq 1
         end
       end
     end

--- a/spec/forms/reference_form_spec.rb
+++ b/spec/forms/reference_form_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 describe ReferenceForm do
   describe "#save" do
-    let(:request_host) { 123 }
-
     describe "updating attributes" do
       let!(:reference) { create :unknown_reference }
       let(:params) do
@@ -16,7 +14,7 @@ describe ReferenceForm do
       specify do
         expect(reference.bolton_key).to eq nil
 
-        described_class.new(reference, params, request_host).save
+        described_class.new(reference, params).save
 
         reference.reload
         expect(reference.bolton_key).to eq params[:bolton_key]
@@ -35,18 +33,18 @@ describe ReferenceForm do
         end
 
         it "does not create new `AuthorName`s for existing authors" do
-          expect { described_class.new(reference, params, request_host).save }.
+          expect { described_class.new(reference, params).save }.
             to_not change { AuthorName.count }
         end
 
         it "reuses existing `ReferenceAuthorName`s" do
-          expect { described_class.new(reference, params, request_host).save }.
+          expect { described_class.new(reference, params).save }.
             to_not change { reference.reload.reference_author_name_ids }
         end
 
         it "does not create any versions for the reference" do
           with_versioning do
-            expect { described_class.new(reference, params, request_host).save }.
+            expect { described_class.new(reference, params).save }.
               to_not change { reference.versions.count }
           end
         end
@@ -63,7 +61,7 @@ describe ReferenceForm do
 
           it "creates a single version for the reference" do
             with_versioning do
-              expect { described_class.new(reference, params, request_host).save }.
+              expect { described_class.new(reference, params).save }.
                 to change { reference.versions.count }.by(1)
             end
           end
@@ -79,13 +77,13 @@ describe ReferenceForm do
 
           it "creates a single version for the reference" do
             with_versioning do
-              expect { described_class.new(reference, params, request_host).save }.
+              expect { described_class.new(reference, params).save }.
                 to change { reference.versions.count }.by(1)
             end
           end
 
           it "updates `#author_names_string_cache`" do
-            expect { described_class.new(reference, params, request_host).save }.
+            expect { described_class.new(reference, params).save }.
               to change { reference.author_names_string_cache }.
               from('Batiatus, B.').to("Batiatus, B.; Glaber, G.")
           end
@@ -102,13 +100,13 @@ describe ReferenceForm do
           # TODO: We may want this. See `after_add: :refresh_author_names_caches`.
           xit "creates a single version for the reference" do
             with_versioning do
-              expect { described_class.new(reference, params, request_host).save }.
+              expect { described_class.new(reference, params).save }.
                 to change { reference.versions.count }.by(1)
             end
           end
 
           it "updates `#author_names_string_cache`" do
-            expect { described_class.new(reference, params, request_host).save }.
+            expect { described_class.new(reference, params).save }.
               to change { reference.author_names_string_cache }.
               from('Batiatus, B.').to("Batiatus, B.; Glaber, G.; Borgia, C.")
           end
@@ -131,12 +129,12 @@ describe ReferenceForm do
 
           it 'deletes orphaned `ReferenceAuthorName`s' do
             expect(ReferenceAuthorName.count).to eq 2
-            expect { described_class.new(reference, params, request_host).save }.
+            expect { described_class.new(reference, params).save }.
               to change { ReferenceAuthorName.count }.by(-1)
           end
 
           it "updates `#author_names_string_cache`" do
-            expect { described_class.new(reference, params, request_host).save }.
+            expect { described_class.new(reference, params).save }.
               to change { reference.author_names_string_cache }.
               from('Batiatus, B.; Glaber, G.').to("Batiatus, B.")
           end
@@ -161,7 +159,7 @@ describe ReferenceForm do
         # TODO: Do not create new a `ReferenceDocument`s.
         xit 'does not create a new `ReferenceDocument`s' do
           expect(ReferenceDocument.count).to eq 1
-          expect { described_class.new(reference, params, request_host).save }.
+          expect { described_class.new(reference, params).save }.
             to_not change { ReferenceDocument.count }
         end
       end
@@ -182,12 +180,12 @@ describe ReferenceForm do
       let!(:duplicate) { create :article_reference, author_names: original.author_names }
 
       it "allows a duplicate record to be saved" do
-        expect { described_class.new(duplicate, params, request_host, ignore_duplicates: true).save }.not_to raise_error
+        expect { described_class.new(duplicate, params, ignore_duplicates: true).save }.not_to raise_error
       end
 
       it "checks possible duplication and add to errors, if any found" do
         expect(duplicate.errors).to be_empty
-        expect(described_class.new(duplicate, params, request_host).save).to eq nil
+        expect(described_class.new(duplicate, params).save).to eq nil
         expect(duplicate.errors[:possible_duplicate].first).to include "This may be a duplicate of Fisher"
       end
     end

--- a/spec/models/cached_reference_formatter_spec.rb
+++ b/spec/models/cached_reference_formatter_spec.rb
@@ -50,7 +50,7 @@ describe CachedReferenceFormatter do
 
     describe "#expandable_reference" do
       before do
-        allow(reference).to receive(:url).and_return 'example.com'
+        allow(reference).to receive(:routed_url).and_return 'example.com'
         allow(reference).to receive(:downloadable?).and_return true
       end
 

--- a/spec/models/reference_document_spec.rb
+++ b/spec/models/reference_document_spec.rb
@@ -61,8 +61,7 @@ describe ReferenceDocument do
     end
 
     it "doesn't consider antbase PDFs downloadable by anybody" do
-      url = 'http://antbase.org/ants/publications/4495/4495.pdf'
-      document = described_class.new(url: url, file_file_name: 'bar')
+      document = described_class.new(url: 'http://antbase.org/ants/publications/4495/4495.pdf')
       expect(document.downloadable?).to eq false
     end
   end

--- a/spec/models/reference_document_spec.rb
+++ b/spec/models/reference_document_spec.rb
@@ -4,26 +4,21 @@ describe ReferenceDocument do
   it { is_expected.to be_versioned }
 
   describe 'validations' do
-    it "makes sure it has a protocol" do
-      stub_request(:any, "http://antcat.org/1.pdf").to_return body: "Hello World!"
-      document = create :reference_document
-      document.url = 'antcat.org/1.pdf'
-      document.save!
-      expect(document.reload.url).to eq 'http://antcat.org/1.pdf'
-      document.save!
-      expect(document.reload.url).to eq 'http://antcat.org/1.pdf'
+    it "validates URLs start with a protocol" do
+      document = described_class.new(url: 'antwiki.org/url')
+      expect(document.valid?).to eq false
     end
 
     it "validates the URL" do
-      document = described_class.new(url: ':::')
-      expect(document).not_to be_valid
+      document = described_class.new(url: 'http://:::')
+      expect(document.valid?).to eq false
       expect(document.errors.full_messages).to match_array ['Url is not in a valid format']
     end
 
     it "accepts URLs with spaces" do
-      stub_request(:any, "http://antwiki.org/a%20url").to_return body: "Hello World!"
+      stub_request(:any, "http://antwiki.org/a%20url").to_return(body: "Hello World!")
       document = described_class.new(url: 'http://antwiki.org/a url')
-      expect(document).to be_valid
+      expect(document.valid?).to eq true
     end
   end
 
@@ -35,7 +30,7 @@ describe ReferenceDocument do
   end
 
   describe "#actual_url" do
-    let!(:document) { create :reference_document, url: 'localhost/document.pdf' }
+    let!(:document) { create :reference_document, url: 'http://localhost/document.pdf' }
 
     it "simply be the url, if the document's not on Amazon" do
       expect(document.reload.actual_url).to eq 'http://localhost/document.pdf'

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Reference do
   it { is_expected.to be_versioned }
-  it { is_expected.to delegate_method(:url).to(:document).allow_nil }
+  it { is_expected.to delegate_method(:routed_url).to(:document).allow_nil }
   it { is_expected.to delegate_method(:downloadable?).to(:document).allow_nil }
 
   describe 'relations' do

--- a/spec/services/exporters/antweb/antweb_inline_citation_spec.rb
+++ b/spec/services/exporters/antweb/antweb_inline_citation_spec.rb
@@ -13,7 +13,7 @@ describe Exporters::Antweb::AntwebInlineCitation do
       pagination: '3'
   end
 
-  before { allow(reference).to receive(:url).and_return 'example.com' }
+  before { allow(reference).to receive(:routed_url).and_return 'example.com' }
 
   describe "#call" do
     context "when PDF is not available to the user" do


### PR DESCRIPTION
Meta issue: #924

Changes:

  * Validate protocol of URLs instead of adding it to the `url`.
  * Dynamically generate "antcat.org routed" document links instead of inserting `host` in the `url`.
  * Show ID of reference document and `file_file_name` in the reference form.
  * Update reference documents in place, to avoid creating new reference documents records when saving references (with out without making any changes).
  * Clear document URL when new PDFs are uploaded (we cannot always clear them yet).
  * References can already have both an uploaded file and a URL (see %dbscript:ReferenceDocumentsWithWeirdActualUrls). A new notice is shown in the reference form for such cases. The blue one can be ignored. We want to deal with these later. The same rules are before apply: link any uploaded file first, then the URL if there is any.