### PR TITLE
Preparatory API tweaks

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,5 +1,9 @@
 module Api
   class ApiController < ApplicationController
+    rescue_from ActiveRecord::RecordNotFound do
+      head :not_found
+    end
+
     def index klass
       items = if params[:starts_at]
                 klass.where('id >= ?', params[:starts_at].to_i)
@@ -11,13 +15,7 @@ module Api
     end
 
     def show klass
-      begin
-        item = klass.find(params[:id])
-      rescue ActiveRecord::RecordNotFound
-        render nothing: true, status: :not_found
-        return
-      end
-
+      item = klass.find(params[:id])
       render json: item
     end
   end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -7,7 +7,7 @@ module Api
                 klass.all
               end.order(id: :asc).limit(100)
 
-      render json: items, status: :ok
+      render json: items
     end
 
     def show klass
@@ -18,7 +18,7 @@ module Api
         return
       end
 
-      render json: item, status: :ok
+      render json: item
     end
   end
 end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -5,12 +5,7 @@ module Api
     end
 
     def index klass
-      items = if params[:starts_at]
-                klass.where('id >= ?', params[:starts_at].to_i)
-              else
-                klass.all
-              end.order(id: :asc).limit(100)
-
+      items = with_limit(klass.all)
       render json: items
     end
 
@@ -18,5 +13,15 @@ module Api
       item = klass.find(params[:id])
       render json: item
     end
+
+    private
+
+      def with_limit scope
+        if params[:starts_at]
+          scope.where('id >= ?', params[:starts_at].to_i)
+        else
+          scope
+        end.order(id: :asc).limit(100)
+      end
   end
 end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -4,11 +4,6 @@ module Api
       head :not_found
     end
 
-    def show klass
-      item = klass.find(params[:id])
-      render json: item
-    end
-
     private
 
       def with_limit scope

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -4,11 +4,6 @@ module Api
       head :not_found
     end
 
-    def index klass
-      items = with_limit(klass.all)
-      render json: items
-    end
-
     def show klass
       item = klass.find(params[:id])
       render json: item

--- a/app/controllers/api/v1/author_names_controller.rb
+++ b/app/controllers/api/v1/author_names_controller.rb
@@ -3,7 +3,7 @@ module Api
     class AuthorNamesController < Api::ApiController
       def index
         authors = AuthorName.all
-        render json: authors, status: :ok
+        render json: authors
       end
 
       def show

--- a/app/controllers/api/v1/author_names_controller.rb
+++ b/app/controllers/api/v1/author_names_controller.rb
@@ -2,8 +2,7 @@ module Api
   module V1
     class AuthorNamesController < Api::ApiController
       def index
-        authors = AuthorName.all
-        render json: authors
+        render json: with_limit(AuthorName.all)
       end
 
       def show

--- a/app/controllers/api/v1/author_names_controller.rb
+++ b/app/controllers/api/v1/author_names_controller.rb
@@ -6,7 +6,8 @@ module Api
       end
 
       def show
-        super AuthorName
+        item = AuthorName.find(params[:id])
+        render json: item
       end
     end
   end

--- a/app/controllers/api/v1/authors_controller.rb
+++ b/app/controllers/api/v1/authors_controller.rb
@@ -3,7 +3,7 @@ module Api
     class AuthorsController < Api::ApiController
       def index
         authors = Author.all
-        render json: authors, status: :ok
+        render json: authors
       end
 
       def show

--- a/app/controllers/api/v1/authors_controller.rb
+++ b/app/controllers/api/v1/authors_controller.rb
@@ -2,8 +2,7 @@ module Api
   module V1
     class AuthorsController < Api::ApiController
       def index
-        authors = Author.all
-        render json: authors
+        render json: with_limit(Author.all)
       end
 
       def show

--- a/app/controllers/api/v1/authors_controller.rb
+++ b/app/controllers/api/v1/authors_controller.rb
@@ -6,7 +6,8 @@ module Api
       end
 
       def show
-        super Author
+        item = Author.find(params[:id])
+        render json: item
       end
     end
   end

--- a/app/controllers/api/v1/citations_controller.rb
+++ b/app/controllers/api/v1/citations_controller.rb
@@ -6,7 +6,8 @@ module Api
       end
 
       def show
-        super Citation
+        item = Citation.find(params[:id])
+        render json: item
       end
     end
   end

--- a/app/controllers/api/v1/citations_controller.rb
+++ b/app/controllers/api/v1/citations_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class CitationsController < Api::ApiController
       def index
-        super Citation
+        render json: with_limit(Citation.all)
       end
 
       def show

--- a/app/controllers/api/v1/journals_controller.rb
+++ b/app/controllers/api/v1/journals_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class JournalsController < Api::ApiController
       def index
-        super Journal
+        render json: with_limit(Journal.all)
       end
 
       def show

--- a/app/controllers/api/v1/journals_controller.rb
+++ b/app/controllers/api/v1/journals_controller.rb
@@ -6,7 +6,8 @@ module Api
       end
 
       def show
-        super Journal
+        item = Journal.find(params[:id])
+        render json: item
       end
     end
   end

--- a/app/controllers/api/v1/names_controller.rb
+++ b/app/controllers/api/v1/names_controller.rb
@@ -6,7 +6,8 @@ module Api
       end
 
       def show
-        super Name
+        item = Name.find(params[:id])
+        render json: item
       end
     end
   end

--- a/app/controllers/api/v1/names_controller.rb
+++ b/app/controllers/api/v1/names_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class NamesController < Api::ApiController
       def index
-        super Name
+        render json: with_limit(Name.all)
       end
 
       def show

--- a/app/controllers/api/v1/protonyms_controller.rb
+++ b/app/controllers/api/v1/protonyms_controller.rb
@@ -6,7 +6,8 @@ module Api
       end
 
       def show
-        super Protonym
+        item = Protonym.find(params[:id])
+        render json: item
       end
     end
   end

--- a/app/controllers/api/v1/protonyms_controller.rb
+++ b/app/controllers/api/v1/protonyms_controller.rb
@@ -3,7 +3,7 @@ module Api
     class ProtonymsController < Api::ApiController
       def index
         protonyms = Protonym.all
-        render json: protonyms, status: :ok
+        render json: protonyms
       end
 
       def show

--- a/app/controllers/api/v1/protonyms_controller.rb
+++ b/app/controllers/api/v1/protonyms_controller.rb
@@ -2,8 +2,7 @@ module Api
   module V1
     class ProtonymsController < Api::ApiController
       def index
-        protonyms = Protonym.all
-        render json: protonyms
+        render json: with_limit(Protonym.all)
       end
 
       def show

--- a/app/controllers/api/v1/publishers_controller.rb
+++ b/app/controllers/api/v1/publishers_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class PublishersController < Api::ApiController
       def index
-        super Publisher
+        render json: with_limit(Publisher.all)
       end
 
       def show

--- a/app/controllers/api/v1/publishers_controller.rb
+++ b/app/controllers/api/v1/publishers_controller.rb
@@ -6,7 +6,8 @@ module Api
       end
 
       def show
-        super Publisher
+        item = Publisher.find(params[:id])
+        render json: item
       end
     end
   end

--- a/app/controllers/api/v1/reference_author_names_controller.rb
+++ b/app/controllers/api/v1/reference_author_names_controller.rb
@@ -6,7 +6,8 @@ module Api
       end
 
       def show
-        super ReferenceAuthorName
+        item = ReferenceAuthorName.find(params[:id])
+        render json: item
       end
     end
   end

--- a/app/controllers/api/v1/reference_author_names_controller.rb
+++ b/app/controllers/api/v1/reference_author_names_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class ReferenceAuthorNamesController < Api::ApiController
       def index
-        super ReferenceAuthorName
+        render json: with_limit(ReferenceAuthorName.all)
       end
 
       def show

--- a/app/controllers/api/v1/reference_documents_controller.rb
+++ b/app/controllers/api/v1/reference_documents_controller.rb
@@ -6,7 +6,8 @@ module Api
       end
 
       def show
-        super ReferenceDocument
+        item = ReferenceDocument.find(params[:id])
+        render json: item
       end
     end
   end

--- a/app/controllers/api/v1/reference_documents_controller.rb
+++ b/app/controllers/api/v1/reference_documents_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class ReferenceDocumentsController < Api::ApiController
       def index
-        super ReferenceDocument
+        render json: with_limit(ReferenceDocument.all)
       end
 
       def show

--- a/app/controllers/api/v1/reference_sections_controller.rb
+++ b/app/controllers/api/v1/reference_sections_controller.rb
@@ -6,7 +6,8 @@ module Api
       end
 
       def show
-        super ReferenceSection
+        item = ReferenceSection.find(params[:id])
+        render json: item
       end
     end
   end

--- a/app/controllers/api/v1/reference_sections_controller.rb
+++ b/app/controllers/api/v1/reference_sections_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class ReferenceSectionsController < Api::ApiController
       def index
-        super ReferenceSection
+        render json: with_limit(ReferenceSection.all)
       end
 
       def show

--- a/app/controllers/api/v1/references_controller.rb
+++ b/app/controllers/api/v1/references_controller.rb
@@ -6,7 +6,8 @@ module Api
       end
 
       def show
-        super Reference
+        item = Reference.find(params[:id])
+        render json: item
       end
     end
   end

--- a/app/controllers/api/v1/references_controller.rb
+++ b/app/controllers/api/v1/references_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class ReferencesController < Api::ApiController
       def index
-        super Reference
+        render json: with_limit(Reference.all)
       end
 
       def show

--- a/app/controllers/api/v1/taxa_controller.rb
+++ b/app/controllers/api/v1/taxa_controller.rb
@@ -6,13 +6,7 @@ module Api
       end
 
       def show
-        begin
-          item = Taxon.find(params[:id])
-        rescue ActiveRecord::RecordNotFound
-          render nothing: true, status: :not_found
-          return
-        end
-
+        item = Taxon.find(params[:id])
         render json: item.to_json(methods: :author_citation)
       end
 

--- a/app/controllers/api/v1/taxa_controller.rb
+++ b/app/controllers/api/v1/taxa_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class TaxaController < Api::ApiController
       def index
-        super Taxon
+        render json: with_limit(Taxon.all)
       end
 
       def show

--- a/app/controllers/api/v1/taxa_controller.rb
+++ b/app/controllers/api/v1/taxa_controller.rb
@@ -21,11 +21,7 @@ module Api
           }
         end
 
-        if results.empty?
-          head :not_found
-        else
-          render json: results
-        end
+        render json: results
       end
     end
   end

--- a/app/controllers/api/v1/taxa_controller.rb
+++ b/app/controllers/api/v1/taxa_controller.rb
@@ -13,7 +13,7 @@ module Api
           return
         end
 
-        render json: item.to_json(methods: :author_citation), status: :ok
+        render json: item.to_json(methods: :author_citation)
       end
 
       def search

--- a/app/controllers/api/v1/taxon_history_items_controller.rb
+++ b/app/controllers/api/v1/taxon_history_items_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class TaxonHistoryItemsController < Api::ApiController
       def index
-        super TaxonHistoryItem
+        render json: with_limit(TaxonHistoryItem.all)
       end
 
       def show

--- a/app/controllers/api/v1/taxon_history_items_controller.rb
+++ b/app/controllers/api/v1/taxon_history_items_controller.rb
@@ -6,7 +6,8 @@ module Api
       end
 
       def show
-        super TaxonHistoryItem
+        item = TaxonHistoryItem.find(params[:id])
+        render json: item
       end
     end
   end

--- a/public/api/v1/swagger.yaml
+++ b/public/api/v1/swagger.yaml
@@ -185,7 +185,6 @@ paths:
       operationId: getAuthorNames
       tags:
         - author_names
-
       responses:
         "200":
           description: Array of all author names
@@ -256,7 +255,6 @@ paths:
       responses:
         "200":
           description: Returns 100 citations at a time starting at the specified citation id. If no id is supplied, starts at zero
-
           schema:
             type: array
             items:
@@ -830,6 +828,9 @@ definitions:
       pages:
         type: string
         description: String describing the page range; no standard format
+      forms:
+        type: string
+        description: String describing the forms; no standard format
       notes_taxt:
         type: string
         description: Long field with text and notes
@@ -896,6 +897,9 @@ definitions:
       name:
         type: string
         description: Publisher name
+      place:
+        type: string
+        description: Publisher place
       created_at:
         type: string
         format: date-time
@@ -1034,8 +1038,6 @@ definitions:
         type: string
       subtitle_taxt:
         type: string
-      public:
-        type: boolean
       created_at:
         type: string
         format: date-time

--- a/public/api/v1/swagger.yaml
+++ b/public/api/v1/swagger.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 
 info:
-  version: "1.1.2"
+  version: "1.1.3"
   title: AntCat REST API
   description: Read only API to access antcat.org
   contact:

--- a/spec/controllers/api/api_controller_spec.rb
+++ b/spec/controllers/api/api_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe Api::ApiController do
+  describe "limits" do
+    controller do
+      def index
+        render json: with_limit(Reference.all)
+      end
+    end
+
+    let!(:reference_1) { create :article_reference }
+    let!(:reference_2) { create :article_reference }
+
+    context 'without `params[:starts_at]`' do
+      specify do
+        get :index
+        expect(json_response).to eq([reference_1, reference_2].as_json)
+      end
+    end
+
+    context 'with `params[:starts_at]`' do
+      specify do
+        get :index, params: { starts_at: reference_2.id }
+        expect(json_response).to eq([reference_2].as_json)
+      end
+    end
+  end
+
+  describe "rescuing `ActiveRecord::RecordNotFound`" do
+    controller do
+      def show
+        raise ActiveRecord::RecordNotFound
+      end
+    end
+
+    specify { expect(get(:show, params: { id: 0 })).to have_http_status :not_found }
+  end
+end

--- a/spec/controllers/api/v1/author_names_controller_spec.rb
+++ b/spec/controllers/api/v1/author_names_controller_spec.rb
@@ -5,24 +5,24 @@ describe Api::V1::AuthorNamesController do
     before do
       create :author_name, name: 'Bolton'
       create :author_name, name: 'Fisher'
-      get :index
     end
 
     it "gets all author names keys" do
+      get(:index)
+
       expect(response.body.to_s).to include "Bolton"
       expect(response.body.to_s).to include "Fisher"
       expect(json_response.count).to eq 2
     end
 
-    specify { expect(response).to have_http_status :ok }
+    specify { expect(get(:index)).to have_http_status :ok }
   end
 
   describe "GET show" do
     let!(:author_name) { create :author_name, name: 'Bolton' }
 
-    before { get :show, params: { id: author_name.id } }
-
     specify do
+      get :show, params: { id: author_name.id }
       expect(json_response).to eq(
         {
           "author_name" => {
@@ -36,6 +36,6 @@ describe Api::V1::AuthorNamesController do
       )
     end
 
-    specify { expect(response).to have_http_status :ok }
+    specify { expect(get(:show, params: { id: author_name.id })).to have_http_status :ok }
   end
 end

--- a/spec/controllers/api/v1/author_names_controller_spec.rb
+++ b/spec/controllers/api/v1/author_names_controller_spec.rb
@@ -2,17 +2,10 @@ require 'rails_helper'
 
 describe Api::V1::AuthorNamesController do
   describe "GET index" do
-    before do
-      create :author_name, name: 'Bolton'
-      create :author_name, name: 'Fisher'
-    end
-
-    it "gets all author names keys" do
-      get(:index)
-
-      expect(response.body.to_s).to include "Bolton"
-      expect(response.body.to_s).to include "Fisher"
-      expect(json_response.count).to eq 2
+    specify do
+      author_name = create :author_name, name: 'Fisher'
+      get :index
+      expect(json_response).to eq([author_name.as_json])
     end
 
     specify { expect(get(:index)).to have_http_status :ok }

--- a/spec/controllers/api/v1/authors_controller_spec.rb
+++ b/spec/controllers/api/v1/authors_controller_spec.rb
@@ -5,23 +5,22 @@ describe Api::V1::AuthorsController do
     let!(:author) { create :author }
     let!(:another_author) { create :author }
 
-    before { get :index }
-
     it "gets all author primary keys" do
+      get(:index)
+
       expect(response.body.to_s).to include author.id.to_s
       expect(response.body.to_s).to include another_author.id.to_s
       expect(json_response.count).to eq 2
     end
 
-    specify { expect(response).to have_http_status :ok }
+    specify { expect(get(:index)).to have_http_status :ok }
   end
 
   describe "GET show" do
     let!(:author) { create :author }
 
-    before { get :show, params: { id: author.id } }
-
     specify do
+      get :show, params: { id: author.id }
       expect(json_response).to eq(
         {
           "author" => {
@@ -33,6 +32,6 @@ describe Api::V1::AuthorsController do
       )
     end
 
-    specify { expect(response).to have_http_status :ok }
+    specify { expect(get(:show, params: { id: author.id })).to have_http_status :ok }
   end
 end

--- a/spec/controllers/api/v1/authors_controller_spec.rb
+++ b/spec/controllers/api/v1/authors_controller_spec.rb
@@ -2,15 +2,10 @@ require 'rails_helper'
 
 describe Api::V1::AuthorsController do
   describe "GET index" do
-    let!(:author) { create :author }
-    let!(:another_author) { create :author }
-
-    it "gets all author primary keys" do
-      get(:index)
-
-      expect(response.body.to_s).to include author.id.to_s
-      expect(response.body.to_s).to include another_author.id.to_s
-      expect(json_response.count).to eq 2
+    specify do
+      author = create :author
+      get :index
+      expect(json_response).to eq([author.as_json])
     end
 
     specify { expect(get(:index)).to have_http_status :ok }

--- a/spec/controllers/api/v1/citations_controller_spec.rb
+++ b/spec/controllers/api/v1/citations_controller_spec.rb
@@ -1,18 +1,36 @@
 require 'rails_helper'
 
 describe Api::V1::CitationsController do
-  before do
-    create :citation
-  end
-
   describe "GET index" do
-    it "gets all citations" do
+    specify do
+      citation = create :citation
       get :index
-
-      expect(response.body.to_s).to include "pages"
-      expect(json_response.count).to eq 1
+      expect(json_response).to eq([citation.as_json])
     end
 
     specify { expect(get(:index)).to have_http_status :ok }
+  end
+
+  describe "GET show" do
+    let!(:citation) { create :citation, forms: 'w.', notes_taxt: 'notes_taxt', pages: "42" }
+
+    specify do
+      get :show, params: { id: citation.id }
+      expect(json_response).to eq(
+        {
+          "citation" => {
+            "id" => citation.id,
+            "forms" => 'w.',
+            "notes_taxt" => 'notes_taxt',
+            "pages" => "42",
+            "reference_id" => citation.reference_id,
+            "created_at" => citation.created_at.as_json,
+            "updated_at" => citation.updated_at.as_json
+          }
+        }
+      )
+    end
+
+    specify { expect(get(:show, params: { id: citation.id })).to have_http_status :ok }
   end
 end

--- a/spec/controllers/api/v1/citations_controller_spec.rb
+++ b/spec/controllers/api/v1/citations_controller_spec.rb
@@ -13,9 +13,6 @@ describe Api::V1::CitationsController do
       expect(json_response.count).to eq 1
     end
 
-    it 'returns HTTP 200' do
-      get :index
-      expect(response).to have_http_status :ok
-    end
+    specify { expect(get(:index)).to have_http_status :ok }
   end
 end

--- a/spec/controllers/api/v1/journals_controller_spec.rb
+++ b/spec/controllers/api/v1/journals_controller_spec.rb
@@ -1,12 +1,15 @@
 require 'rails_helper'
 
 describe Api::V1::JournalsController do
+  describe "GET index" do
+    specify { expect(get(:index)).to have_http_status :ok }
+  end
+
   describe "GET show" do
     let!(:journal) { create :journal, name: 'Zootaxa' }
 
-    before { get :show, params: { id: journal.id } }
-
     specify do
+      get :show, params: { id: journal.id }
       expect(json_response).to eq(
         {
           "journal" => {
@@ -19,6 +22,6 @@ describe Api::V1::JournalsController do
       )
     end
 
-    specify { expect(response).to have_http_status :ok }
+    specify { expect(get(:show, params: { id: journal.id })).to have_http_status :ok }
   end
 end

--- a/spec/controllers/api/v1/journals_controller_spec.rb
+++ b/spec/controllers/api/v1/journals_controller_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 describe Api::V1::JournalsController do
   describe "GET index" do
+    specify do
+      journal = create :journal, name: 'Zootaxa'
+      get :index
+      expect(json_response).to eq([journal.as_json])
+    end
+
     specify { expect(get(:index)).to have_http_status :ok }
   end
 

--- a/spec/controllers/api/v1/names_controller_spec.rb
+++ b/spec/controllers/api/v1/names_controller_spec.rb
@@ -2,36 +2,23 @@ require 'rails_helper'
 
 describe Api::V1::NamesController do
   describe "GET index" do
-    let!(:family_name) { create :family_name }
-    let!(:species_name) { create :species_name }
-
-    it "gets all names keys" do
+    specify do
+      name = create :family_name
       get :index
-
-      expect(response.body.to_s).to include family_name.name
-      expect(response.body.to_s).to include species_name.name
-      expect(json_response.count).to eq 2
-    end
-
-    it "gets all names keys (starts_at)" do
-      get :index, params: { starts_at: species_name.id }
-
-      expect(json_response[0]['species_name']['id']).to eq species_name.id
-      expect(json_response.count).to eq 1
+      expect(json_response).to eq([name.as_json])
     end
 
     specify { expect(get(:index)).to have_http_status :ok }
   end
 
   describe "GET show" do
-    let!(:taxon) { create :family }
+    let!(:name) { create :family_name }
 
-    before { get :show, params: { id: taxon.name_id } }
-
-    it "fetches a name" do
-      expect(response.body.to_s).to include taxon.name.name
+    specify do
+      get :show, params: { id: name.id }
+      expect(json_response).to eq(name.as_json) # TOOD: Lazy.
     end
 
-    specify { expect(response).to have_http_status :ok }
+    specify { expect(get(:show, params: { id: name.id })).to have_http_status :ok }
   end
 end

--- a/spec/controllers/api/v1/names_controller_spec.rb
+++ b/spec/controllers/api/v1/names_controller_spec.rb
@@ -20,10 +20,7 @@ describe Api::V1::NamesController do
       expect(json_response.count).to eq 1
     end
 
-    it 'returns HTTP 200' do
-      get :index
-      expect(response).to have_http_status :ok
-    end
+    specify { expect(get(:index)).to have_http_status :ok }
   end
 
   describe "GET show" do

--- a/spec/controllers/api/v1/protonyms_controller_spec.rb
+++ b/spec/controllers/api/v1/protonyms_controller_spec.rb
@@ -4,22 +4,21 @@ describe Api::V1::ProtonymsController do
   describe "GET index" do
     before do
       create :protonym
-      get :index
     end
 
     it "gets all protonyms" do
+      get :index
       expect(json_response.count).to eq 1
     end
 
-    specify { expect(response).to have_http_status :ok }
+    specify { expect(get(:index)).to have_http_status :ok }
   end
 
   describe "GET show" do
     let!(:protonym) { create :protonym, :with_taxts, biogeographic_region: Protonym::NEARCTIC_REGION, locality: "USA" }
 
-    before { get :show, params: { id: protonym.id } }
-
     specify do
+      get :show, params: { id: protonym.id }
       expect(json_response).to eq(
         {
           "protonym" => {
@@ -40,6 +39,6 @@ describe Api::V1::ProtonymsController do
       )
     end
 
-    specify { expect(response).to have_http_status :ok }
+    specify { expect(get(:show, params: { id: protonym.id })).to have_http_status :ok }
   end
 end

--- a/spec/controllers/api/v1/protonyms_controller_spec.rb
+++ b/spec/controllers/api/v1/protonyms_controller_spec.rb
@@ -2,13 +2,10 @@ require 'rails_helper'
 
 describe Api::V1::ProtonymsController do
   describe "GET index" do
-    before do
-      create :protonym
-    end
-
-    it "gets all protonyms" do
+    specify do
+      protonym = create :protonym
       get :index
-      expect(json_response.count).to eq 1
+      expect(json_response).to eq([protonym.as_json])
     end
 
     specify { expect(get(:index)).to have_http_status :ok }

--- a/spec/controllers/api/v1/publishers_controller_spec.rb
+++ b/spec/controllers/api/v1/publishers_controller_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 describe Api::V1::PublishersController do
   describe "GET index" do
+    specify do
+      publisher = create :publisher
+      get :index
+      expect(json_response).to eq([publisher.as_json])
+    end
+
     specify { expect(get(:index)).to have_http_status :ok }
   end
 

--- a/spec/controllers/api/v1/publishers_controller_spec.rb
+++ b/spec/controllers/api/v1/publishers_controller_spec.rb
@@ -1,12 +1,15 @@
 require 'rails_helper'
 
 describe Api::V1::PublishersController do
+  describe "GET index" do
+    specify { expect(get(:index)).to have_http_status :ok }
+  end
+
   describe "GET show" do
     let!(:publisher) { create :publisher, name: 'AntPress', place: 'California' }
 
-    before { get :show, params: { id: publisher.id } }
-
     specify do
+      get :show, params: { id: publisher.id }
       expect(json_response).to eq(
         {
           "publisher" => {
@@ -20,6 +23,6 @@ describe Api::V1::PublishersController do
       )
     end
 
-    specify { expect(response).to have_http_status :ok }
+    specify { expect(get(:show, params: { id: publisher.id })).to have_http_status :ok }
   end
 end

--- a/spec/controllers/api/v1/reference_author_names_controller_spec.rb
+++ b/spec/controllers/api/v1/reference_author_names_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe Api::V1::ReferenceAuthorNamesController do
+  describe "GET index" do
+    specify do
+      create :reference_author_name
+      get :index
+      expect(json_response).to eq(ReferenceAuthorName.all.as_json)
+    end
+
+    specify { expect(get(:index)).to have_http_status :ok }
+  end
+
+  describe "GET show" do
+    let!(:reference_author_name) { create :reference_author_name }
+
+    specify do
+      get :show, params: { id: reference_author_name.id }
+      expect(json_response).to eq(
+        {
+          "reference_author_name" => {
+            "id" => reference_author_name.id,
+            "author_name_id" => reference_author_name.author_name_id,
+            "reference_id" => reference_author_name.reference_id,
+            "position" => reference_author_name.position,
+            "created_at" => reference_author_name.created_at.as_json,
+            "updated_at" => reference_author_name.updated_at.as_json
+          }
+        }
+      )
+    end
+
+    specify { expect(get(:show, params: { id: reference_author_name.id })).to have_http_status :ok }
+  end
+end

--- a/spec/controllers/api/v1/reference_documents_controller_spec.rb
+++ b/spec/controllers/api/v1/reference_documents_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe Api::V1::ReferenceDocumentsController do
+  describe "GET index" do
+    specify do
+      reference_document = create :reference_document
+      get :index
+      expect(json_response).to eq([reference_document.as_json])
+    end
+
+    specify { expect(get(:index)).to have_http_status :ok }
+  end
+
+  describe "GET show" do
+    let!(:reference_document) { create :reference_document }
+
+    specify do
+      get :show, params: { id: reference_document.id }
+      expect(json_response).to eq(
+        {
+          "reference_document" => {
+            "id" => reference_document.id,
+            "reference_id" => reference_document.reference_id,
+            "file_file_name" => reference_document.file_file_name,
+            "url" => reference_document.url,
+            "public" => reference_document.public,
+            "created_at" => reference_document.created_at.as_json,
+            "updated_at" => reference_document.updated_at.as_json
+          }
+        }
+      )
+    end
+
+    specify { expect(get(:show, params: { id: reference_document.id })).to have_http_status :ok }
+  end
+end

--- a/spec/controllers/api/v1/reference_sections_controller_spec.rb
+++ b/spec/controllers/api/v1/reference_sections_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe Api::V1::ReferenceSectionsController do
+  describe "GET index" do
+    specify do
+      reference_section = create :reference_section
+      get :index
+      expect(json_response).to eq([reference_section.as_json])
+    end
+
+    specify { expect(get(:index)).to have_http_status :ok }
+  end
+
+  describe "GET show" do
+    let!(:reference_section) { create :reference_section, :with_all_taxts }
+
+    specify do
+      get :show, params: { id: reference_section.id }
+      expect(json_response).to eq(
+        {
+          "reference_section" => {
+            "id" => reference_section.id,
+            "taxon_id" => reference_section.taxon_id,
+            "position" => reference_section.position,
+            "title_taxt" => reference_section.title_taxt,
+            "references_taxt" => reference_section.references_taxt,
+            "subtitle_taxt" => reference_section.subtitle_taxt,
+            "created_at" => reference_section.created_at.as_json,
+            "updated_at" => reference_section.updated_at.as_json
+          }
+        }
+      )
+    end
+
+    specify { expect(get(:show, params: { id: reference_section.id })).to have_http_status :ok }
+  end
+end

--- a/spec/controllers/api/v1/references_controller_spec.rb
+++ b/spec/controllers/api/v1/references_controller_spec.rb
@@ -2,41 +2,47 @@ require 'rails_helper'
 
 describe Api::V1::ReferencesController do
   describe "GET show" do
-    let!(:reference) { create :article_reference }
+    context 'when record exists' do
+      let!(:reference) { create :article_reference }
 
-    it "returns a single reference" do
-      get :show, params: { id: reference.id }
+      specify do
+        get :show, params: { id: reference.id }
 
-      expect(json_response['article_reference']).to eq(
-        "author_names_string_cache" => reference.author_names_string_cache,
-        "author_names_suffix" => nil,
-        "bolton_key" => nil,
-        "citation" => nil,
-        "citation_year" => reference.citation_year,
-        "created_at" => reference.created_at.as_json,
-        "date" => nil,
-        "doi" => nil,
-        "editor_notes" => nil,
-        "expandable_reference_cache" => nil,
-        "expanded_reference_cache" => nil,
-        "id" => reference.id,
-        "journal_id" => reference.journal_id,
-        "nesting_reference_id" => nil,
-        "online_early" => false,
-        "pagination" => reference.pagination,
-        "plain_text_cache" => nil,
-        "public_notes" => nil,
-        "publisher_id" => nil,
-        "reason_missing" => nil,
-        "review_state" => "none",
-        "series_volume_issue" => reference.series_volume_issue,
-        "taxonomic_notes" => nil,
-        "title" => reference.title,
-        "updated_at" => reference.updated_at.as_json,
-        "year" => reference.year
-      )
+        expect(json_response).to eq(
+          {
+            "article_reference" => {
+              "author_names_string_cache" => reference.author_names_string_cache,
+              "author_names_suffix" => nil,
+              "bolton_key" => nil,
+              "citation" => nil,
+              "citation_year" => reference.citation_year,
+              "created_at" => reference.created_at.as_json,
+              "date" => nil,
+              "doi" => nil,
+              "editor_notes" => nil,
+              "expandable_reference_cache" => nil,
+              "expanded_reference_cache" => nil,
+              "id" => reference.id,
+              "journal_id" => reference.journal_id,
+              "nesting_reference_id" => nil,
+              "online_early" => false,
+              "pagination" => reference.pagination,
+              "plain_text_cache" => nil,
+              "public_notes" => nil,
+              "publisher_id" => nil,
+              "reason_missing" => nil,
+              "review_state" => "none",
+              "series_volume_issue" => reference.series_volume_issue,
+              "taxonomic_notes" => nil,
+              "title" => reference.title,
+              "updated_at" => reference.updated_at.as_json,
+              "year" => reference.year
+            }
+          }
+        )
+      end
+
+      specify { expect(get(:show, params: { id: reference.id })).to have_http_status :ok }
     end
-
-    specify { expect(get(:show, params: { id: reference.id })).to have_http_status :ok }
   end
 end

--- a/spec/controllers/api/v1/references_controller_spec.rb
+++ b/spec/controllers/api/v1/references_controller_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 describe Api::V1::ReferencesController do
   describe "GET index" do
+    specify do
+      reference = create :article_reference
+      get :index
+      expect(json_response).to eq([reference.as_json])
+    end
+
     specify { expect(get(:index)).to have_http_status :ok }
   end
 

--- a/spec/controllers/api/v1/references_controller_spec.rb
+++ b/spec/controllers/api/v1/references_controller_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 describe Api::V1::ReferencesController do
   describe "GET show" do
+    context 'when record does not exists' do
+      specify { expect(get(:show, params: { id: 0 })).to have_http_status :not_found }
+    end
+
     context 'when record exists' do
       let!(:reference) { create :article_reference }
 

--- a/spec/controllers/api/v1/references_controller_spec.rb
+++ b/spec/controllers/api/v1/references_controller_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 describe Api::V1::ReferencesController do
+  describe "GET index" do
+    specify { expect(get(:index)).to have_http_status :ok }
+  end
+
   describe "GET show" do
     context 'when record does not exists' do
       specify { expect(get(:show, params: { id: 0 })).to have_http_status :not_found }
@@ -11,7 +15,6 @@ describe Api::V1::ReferencesController do
 
       specify do
         get :show, params: { id: reference.id }
-
         expect(json_response).to eq(
           {
             "article_reference" => {

--- a/spec/controllers/api/v1/references_controller_spec.rb
+++ b/spec/controllers/api/v1/references_controller_spec.rb
@@ -12,50 +12,44 @@ describe Api::V1::ReferencesController do
   end
 
   describe "GET show" do
-    context 'when record does not exists' do
-      specify { expect(get(:show, params: { id: 0 })).to have_http_status :not_found }
-    end
+    let!(:reference) { create :article_reference }
 
-    context 'when record exists' do
-      let!(:reference) { create :article_reference }
-
-      specify do
-        get :show, params: { id: reference.id }
-        expect(json_response).to eq(
-          {
-            "article_reference" => {
-              "author_names_string_cache" => reference.author_names_string_cache,
-              "author_names_suffix" => nil,
-              "bolton_key" => nil,
-              "citation" => nil,
-              "citation_year" => reference.citation_year,
-              "created_at" => reference.created_at.as_json,
-              "date" => nil,
-              "doi" => nil,
-              "editor_notes" => nil,
-              "expandable_reference_cache" => nil,
-              "expanded_reference_cache" => nil,
-              "id" => reference.id,
-              "journal_id" => reference.journal_id,
-              "nesting_reference_id" => nil,
-              "online_early" => false,
-              "pagination" => reference.pagination,
-              "plain_text_cache" => nil,
-              "public_notes" => nil,
-              "publisher_id" => nil,
-              "reason_missing" => nil,
-              "review_state" => "none",
-              "series_volume_issue" => reference.series_volume_issue,
-              "taxonomic_notes" => nil,
-              "title" => reference.title,
-              "updated_at" => reference.updated_at.as_json,
-              "year" => reference.year
-            }
+    specify do
+      get :show, params: { id: reference.id }
+      expect(json_response).to eq(
+        {
+          "article_reference" => {
+            "author_names_string_cache" => reference.author_names_string_cache,
+            "author_names_suffix" => nil,
+            "bolton_key" => nil,
+            "citation" => nil,
+            "citation_year" => reference.citation_year,
+            "created_at" => reference.created_at.as_json,
+            "date" => nil,
+            "doi" => nil,
+            "editor_notes" => nil,
+            "expandable_reference_cache" => nil,
+            "expanded_reference_cache" => nil,
+            "id" => reference.id,
+            "journal_id" => reference.journal_id,
+            "nesting_reference_id" => nil,
+            "online_early" => false,
+            "pagination" => reference.pagination,
+            "plain_text_cache" => nil,
+            "public_notes" => nil,
+            "publisher_id" => nil,
+            "reason_missing" => nil,
+            "review_state" => "none",
+            "series_volume_issue" => reference.series_volume_issue,
+            "taxonomic_notes" => nil,
+            "title" => reference.title,
+            "updated_at" => reference.updated_at.as_json,
+            "year" => reference.year
           }
-        )
-      end
-
-      specify { expect(get(:show, params: { id: reference.id })).to have_http_status :ok }
+        }
+      )
     end
+
+    specify { expect(get(:show, params: { id: reference.id })).to have_http_status :ok }
   end
 end

--- a/spec/controllers/api/v1/taxa_controller_spec.rb
+++ b/spec/controllers/api/v1/taxa_controller_spec.rb
@@ -29,6 +29,10 @@ describe Api::V1::TaxaController do
   end
 
   describe "GET show" do
+    context 'when record does not exists' do
+      specify { expect(get(:show, params: { id: 0 })).to have_http_status :not_found }
+    end
+
     context 'when record exists' do
       let!(:taxon) { create :species }
 

--- a/spec/controllers/api/v1/taxa_controller_spec.rb
+++ b/spec/controllers/api/v1/taxa_controller_spec.rb
@@ -26,57 +26,51 @@ describe Api::V1::TaxaController do
   end
 
   describe "GET show" do
-    context 'when record does not exists' do
-      specify { expect(get(:show, params: { id: 0 })).to have_http_status :not_found }
-    end
+    let!(:taxon) { create :species }
 
-    context 'when record exists' do
-      let!(:taxon) { create :species }
-
-      specify do
-        get :show, params: { id: taxon.id }
-        expect(json_response).to eq(
-          {
-            "species" => {
-              "auto_generated" => false,
-              "collective_group_name" => false,
-              "created_at" => taxon.created_at.as_json,
-              "current_valid_taxon_id" => nil,
-              "family_id" => nil,
-              "fossil" => false,
-              "genus_id" => taxon.genus_id,
-              "headline_notes_taxt" => nil,
-              "hol_id" => nil,
-              "homonym_replaced_by_id" => nil,
-              "hong" => false,
-              "ichnotaxon" => false,
-              "id" => taxon.id,
-              "incertae_sedis_in" => nil,
-              "name_cache" => taxon.name_cache,
-              "name_html_cache" => taxon.name_html_cache,
-              "name_id" => taxon.name_id,
-              "nomen_nudum" => false,
-              "origin" => nil,
-              "original_combination" => false,
-              "protonym_id" => taxon.protonym_id,
-              "species_id" => nil,
-              "status" => "valid",
-              "subfamily_id" => taxon.subfamily_id,
-              "subgenus_id" => nil,
-              "subspecies_id" => nil,
-              "tribe_id" => taxon.tribe_id,
-              "type_taxon_id" => nil,
-              "type_taxt" => nil,
-              "unresolved_homonym" => false,
-              "updated_at" => taxon.updated_at.as_json,
-              "author_citation" => taxon.author_citation
-            }
+    specify do
+      get :show, params: { id: taxon.id }
+      expect(json_response).to eq(
+        {
+          "species" => {
+            "auto_generated" => false,
+            "collective_group_name" => false,
+            "created_at" => taxon.created_at.as_json,
+            "current_valid_taxon_id" => nil,
+            "family_id" => nil,
+            "fossil" => false,
+            "genus_id" => taxon.genus_id,
+            "headline_notes_taxt" => nil,
+            "hol_id" => nil,
+            "homonym_replaced_by_id" => nil,
+            "hong" => false,
+            "ichnotaxon" => false,
+            "id" => taxon.id,
+            "incertae_sedis_in" => nil,
+            "name_cache" => taxon.name_cache,
+            "name_html_cache" => taxon.name_html_cache,
+            "name_id" => taxon.name_id,
+            "nomen_nudum" => false,
+            "origin" => nil,
+            "original_combination" => false,
+            "protonym_id" => taxon.protonym_id,
+            "species_id" => nil,
+            "status" => "valid",
+            "subfamily_id" => taxon.subfamily_id,
+            "subgenus_id" => nil,
+            "subspecies_id" => nil,
+            "tribe_id" => taxon.tribe_id,
+            "type_taxon_id" => nil,
+            "type_taxt" => nil,
+            "unresolved_homonym" => false,
+            "updated_at" => taxon.updated_at.as_json,
+            "author_citation" => taxon.author_citation
           }
-        )
-      end
-
-      specify { expect(get(:show, params: { id: taxon.id })).to have_http_status :ok }
+        }
+      )
     end
+
+    specify { expect(get(:show, params: { id: taxon.id })).to have_http_status :ok }
   end
 
   describe "GET search" do

--- a/spec/controllers/api/v1/taxa_controller_spec.rb
+++ b/spec/controllers/api/v1/taxa_controller_spec.rb
@@ -72,9 +72,9 @@ describe Api::V1::TaxaController do
     end
 
     context "when there are no search matches" do
-      it 'returns HTTP 404' do
-        get :search, params: { string: 'maxuus' }
-        expect(response).to have_http_status :not_found
+      it 'returns an empty array' do
+        get :search, params: { string: 'pizza' }
+        expect(json_response).to eq([])
       end
     end
   end

--- a/spec/controllers/api/v1/taxa_controller_spec.rb
+++ b/spec/controllers/api/v1/taxa_controller_spec.rb
@@ -22,10 +22,7 @@ describe Api::V1::TaxaController do
       expect(json_response.count).to eq 1
     end
 
-    it 'returns HTTP 200' do
-      get :index
-      expect(response).to have_http_status :ok
-    end
+    specify { expect(get(:index)).to have_http_status :ok }
   end
 
   describe "GET show" do
@@ -38,7 +35,6 @@ describe Api::V1::TaxaController do
 
       specify do
         get :show, params: { id: taxon.id }
-
         expect(json_response).to eq(
           {
             "species" => {

--- a/spec/controllers/api/v1/taxa_controller_spec.rb
+++ b/spec/controllers/api/v1/taxa_controller_spec.rb
@@ -29,48 +29,54 @@ describe Api::V1::TaxaController do
   end
 
   describe "GET show" do
-    let!(:taxon) { create :species }
+    context 'when record exists' do
+      let!(:taxon) { create :species }
 
-    before { get :show, params: { id: taxon.id } }
+      specify do
+        get :show, params: { id: taxon.id }
 
-    it "returns a single taxon entry" do
-      expect(json_response['species']).to eq(
-        "auto_generated" => false,
-        "collective_group_name" => false,
-        "created_at" => taxon.created_at.as_json,
-        "current_valid_taxon_id" => nil,
-        "family_id" => nil,
-        "fossil" => false,
-        "genus_id" => taxon.genus_id,
-        "headline_notes_taxt" => nil,
-        "hol_id" => nil,
-        "homonym_replaced_by_id" => nil,
-        "hong" => false,
-        "ichnotaxon" => false,
-        "id" => taxon.id,
-        "incertae_sedis_in" => nil,
-        "name_cache" => taxon.name_cache,
-        "name_html_cache" => taxon.name_html_cache,
-        "name_id" => taxon.name_id,
-        "nomen_nudum" => false,
-        "origin" => nil,
-        "original_combination" => false,
-        "protonym_id" => taxon.protonym_id,
-        "species_id" => nil,
-        "status" => "valid",
-        "subfamily_id" => taxon.subfamily_id,
-        "subgenus_id" => nil,
-        "subspecies_id" => nil,
-        "tribe_id" => taxon.tribe_id,
-        "type_taxon_id" => nil,
-        "type_taxt" => nil,
-        "unresolved_homonym" => false,
-        "updated_at" => taxon.updated_at.as_json,
-        "author_citation" => taxon.author_citation
-      )
+        expect(json_response).to eq(
+          {
+            "species" => {
+              "auto_generated" => false,
+              "collective_group_name" => false,
+              "created_at" => taxon.created_at.as_json,
+              "current_valid_taxon_id" => nil,
+              "family_id" => nil,
+              "fossil" => false,
+              "genus_id" => taxon.genus_id,
+              "headline_notes_taxt" => nil,
+              "hol_id" => nil,
+              "homonym_replaced_by_id" => nil,
+              "hong" => false,
+              "ichnotaxon" => false,
+              "id" => taxon.id,
+              "incertae_sedis_in" => nil,
+              "name_cache" => taxon.name_cache,
+              "name_html_cache" => taxon.name_html_cache,
+              "name_id" => taxon.name_id,
+              "nomen_nudum" => false,
+              "origin" => nil,
+              "original_combination" => false,
+              "protonym_id" => taxon.protonym_id,
+              "species_id" => nil,
+              "status" => "valid",
+              "subfamily_id" => taxon.subfamily_id,
+              "subgenus_id" => nil,
+              "subspecies_id" => nil,
+              "tribe_id" => taxon.tribe_id,
+              "type_taxon_id" => nil,
+              "type_taxt" => nil,
+              "unresolved_homonym" => false,
+              "updated_at" => taxon.updated_at.as_json,
+              "author_citation" => taxon.author_citation
+            }
+          }
+        )
+      end
+
+      specify { expect(get(:show, params: { id: taxon.id })).to have_http_status :ok }
     end
-
-    specify { expect(response).to have_http_status :ok }
   end
 
   describe "GET search" do

--- a/spec/controllers/api/v1/taxa_controller_spec.rb
+++ b/spec/controllers/api/v1/taxa_controller_spec.rb
@@ -2,24 +2,10 @@ require 'rails_helper'
 
 describe Api::V1::TaxaController do
   describe "GET index" do
-    it "gets all taxa greater than a given number" do
-      create :genus
-      create :species
-      species = create :species
-
-      get :index, params: { starts_at: species.id }
-
-      expect(json_response[0]['species']['id']).to eq species.id
-      expect(json_response.count).to eq 1
-    end
-
-    it "gets all taxa" do
+    specify do
       taxon = create :family
-
       get :index
-
-      expect(response.body.to_s).to include taxon.name.name
-      expect(json_response.count).to eq 1
+      expect(json_response).to eq([taxon.as_json])
     end
 
     specify { expect(get(:index)).to have_http_status :ok }
@@ -74,16 +60,15 @@ describe Api::V1::TaxaController do
   end
 
   describe "GET search" do
-    before { create :species, name_string: 'Atta minor maxus' }
+    let!(:taxon) { create :species, name_string: 'Atta minor maxus' }
 
-    it "searches for taxa" do
+    specify do
       get :search, params: { string: 'maxus' }
-      expect(response.body.to_s).to include "maxus"
-    end
-
-    it 'returns HTTP 200' do
-      get :search, params: { string: 'maxus' }
-      expect(response).to have_http_status :ok
+      expect(json_response).to eq(
+        [
+          { "id" => taxon.id, "name" => taxon.name_cache }
+        ]
+      )
     end
 
     context "when there are no search matches" do

--- a/spec/controllers/api/v1/taxon_history_items_controller_spec.rb
+++ b/spec/controllers/api/v1/taxon_history_items_controller_spec.rb
@@ -1,16 +1,35 @@
 require 'rails_helper'
 
 describe Api::V1::TaxonHistoryItemsController do
-  before { 2.times { create :taxon_history_item } }
-
   describe "GET index" do
-    it "gets all taxon_history_items" do
+    specify do
+      taxon_history_item = create :taxon_history_item
       get :index
-
-      expect(response.body.to_s).to include "position"
-      expect(json_response.count).to eq 2
+      expect(json_response).to eq([taxon_history_item.as_json])
     end
 
     specify { expect(get(:index)).to have_http_status :ok }
+  end
+
+  describe "GET show" do
+    let!(:taxon_history_item) { create :taxon_history_item }
+
+    specify do
+      get :show, params: { id: taxon_history_item.id }
+      expect(json_response).to eq(
+        {
+          "taxon_history_item" => {
+            "id" => taxon_history_item.id,
+            "taxon_id" => taxon_history_item.taxon_id,
+            "position" => taxon_history_item.position,
+            "taxt" => taxon_history_item.taxt,
+            "created_at" => taxon_history_item.created_at.as_json,
+            "updated_at" => taxon_history_item.updated_at.as_json
+          }
+        }
+      )
+    end
+
+    specify { expect(get(:show, params: { id: taxon_history_item.id })).to have_http_status :ok }
   end
 end

--- a/spec/controllers/api/v1/taxon_history_items_controller_spec.rb
+++ b/spec/controllers/api/v1/taxon_history_items_controller_spec.rb
@@ -11,9 +11,6 @@ describe Api::V1::TaxonHistoryItemsController do
       expect(json_response.count).to eq 2
     end
 
-    it 'returns HTTP 200' do
-      get :index
-      expect(response).to have_http_status :ok
-    end
+    specify { expect(get(:index)).to have_http_status :ok }
   end
 end

--- a/spec/factories/reference_author_names.rb
+++ b/spec/factories/reference_author_names.rb
@@ -1,3 +1,5 @@
+# TODO: This creates two `ReferenceAuthorName`; one additional for the reference.
+
 FactoryBot.define do
   factory :reference_author_name do
     association :reference

--- a/spec/factories/reference_sections.rb
+++ b/spec/factories/reference_sections.rb
@@ -3,5 +3,11 @@ FactoryBot.define do
     association :taxon, factory: :family
     sequence(:position) { |n| n }
     sequence(:references_taxt) { |n| "Reference #{n}" }
+
+    trait :with_all_taxts do
+      sequence(:title_taxt) { |n| "title_taxt #{n}" }
+      sequence(:references_taxt) { |n| "references_taxt #{n}" }
+      sequence(:subtitle_taxt) { |n| "subtitle_taxt #{n}" }
+    end
   end
 end


### PR DESCRIPTION
Prepare code and specs to that we can serializer different models differently, intead of always using `#to_json`.