### PR TITLE
Disallow more bots

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,14 +18,12 @@ module ApplicationHelper
     AddPeriodIfNecessary[string]
   end
 
-  # TODO: See if we can use CSS only instead.
   def external_link_to label, url
     link_to label, url, class: 'external-link'
   end
 
-  # TODO: See if we can use CSS only instead.
   def pdf_link_to label, url
-    link_to label, url, class: 'pdf-link'
+    link_to label, url, class: 'pdf-link', rel: 'nofollow'
   end
 
   def yes_no_options_for_select value

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,12 @@
 User-agent: *
 Allow: /
+Disallow: /activities/
+Disallow: /documents/
+Disallow: /feedback/
+Disallow: /references/exports/
+Disallow: *.pdf
+Disallow: /*history$
+Disallow: /*exports/wikipedia$
 
 # https://ahrefs.com/robot
 User-agent: AhrefsBot

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,6 +8,8 @@ Disallow: *.pdf
 Disallow: /*history$
 Disallow: /*exports/wikipedia$
 
+Crawl-delay: 10
+
 # https://ahrefs.com/robot
 User-agent: AhrefsBot
 Disallow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,26 @@
 User-agent: *
 Allow: /
 
+# https://ahrefs.com/robot
 User-agent: AhrefsBot
+Disallow: /
+
+# http://webmeup-crawler.com/
+User-agent: BLEXBot
+Disallow: /
+
+# https://moz.com/help/moz-procedures/crawlers/dotbot
+User-agent: dotbot
+Disallow: /
+
+# http://megaindex.com/crawler
+User-agent: MegaIndex.ru
+Disallow: /
+
+# https://megaindex.com/crawler
+User-agent: MJ12bot
+Disallow: /
+
+# https://www.semrush.com/bot/
+User-agent: SemrushBot
 Disallow: /

--- a/spec/decorators/reference_decorator_spec.rb
+++ b/spec/decorators/reference_decorator_spec.rb
@@ -34,7 +34,7 @@ describe ReferenceDecorator do
     end
 
     it "creates a link" do
-      expect(decorated.format_document_links).to eq '<a class="pdf-link" href="example.com">PDF</a>'
+      expect(decorated.format_document_links).to eq '<a class="pdf-link" rel="nofollow" href="example.com">PDF</a>'
     end
   end
 

--- a/spec/injectable_formatters/antweb_formatter/reference_link_spec.rb
+++ b/spec/injectable_formatters/antweb_formatter/reference_link_spec.rb
@@ -38,7 +38,7 @@ describe AntwebFormatter::ReferenceLink do
           %{<a title="Latreille, P. A. 1809. Atta. Science (1):3." } +
           %(href="https://antcat.org/references/#{reference.id}">Latreille, 1809</a>) +
           %( <a class="external-link" href="https://doi.org/#{reference.doi}">#{reference.doi}</a>) +
-          %( <a class="pdf-link" href="example.com">PDF</a>)
+          %( <a class="pdf-link" rel="nofollow" href="example.com">PDF</a>)
         )
       end
     end

--- a/spec/services/references/formatted/expandable_spec.rb
+++ b/spec/services/references/formatted/expandable_spec.rb
@@ -26,7 +26,7 @@ describe References::Formatted::Expandable do
             <a href=&quot;/references/#{reference.id}&quot;><i>Atta</i> <i>and such</i>.</a>
             #{reference.journal.name} (1):3.
             <a class=&quot;external-link&quot; href=&quot;https://doi.org/#{reference.doi}&quot;>#{reference.doi}</a>
-            <a class=&quot;pdf-link&quot; href=&quot;example.com&quot;>PDF</a>">Forel, 1874</span>
+            <a class=&quot;pdf-link&quot; rel=&quot;nofollow&quot; href=&quot;example.com&quot;>PDF</a>">Forel, 1874</span>
       HTML
     end
   end


### PR DESCRIPTION
From today:

```
awk -F"\"" '{print $6}' /var/log/nginx/antcat.ssl.access.log | sort | uniq -dc | sort -nr

   5581 Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)
   5273 Mozilla/5.0 (compatible; MegaIndex.ru/2.0; +http://megaindex.com/crawler)
   3163 Mozilla/5.0 (compatible; SemrushBot/6~bl; +http://www.semrush.com/bot.html)
   2024 Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)
   1286 Sogou web spider/4.0(+http://www.sogou.com/docs/help/webmasters.htm#07)
    963 Mozilla/5.0 (compatible; DotBot/1.1; http://www.opensiteexplorer.org/dotbot, help@moz.com)
    731 Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; AspiegelBot)
    679 Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.113 Safari/537.36
    609 Mozilla/5.0 (compatible; Qwantify/2.4w; +https://www.qwant.com/)/2.4w
```

From a few days ago:
```
awk -F"\"" '{print $6}' /var/log/nginx/antcat.ssl.access.log | sort | uniq -dc | sort -nr

  47632 Mozilla/5.0 (compatible; AhrefsBot/6.1; +http://ahrefs.com/robot/)
  10923 Mozilla/5.0 (compatible; BLEXBot/1.0; +http://webmeup-crawler.com/)
   6392 Mozilla/5.0 (compatible; MegaIndex.ru/2.0; +http://megaindex.com/crawler)
   3470 Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)
   2678 Mozilla/5.0 (compatible; SemrushBot/6~bl; +http://www.semrush.com/bot.html)
   2387 Mozilla/5.0 (compatible; DotBot/1.1; http://www.opensiteexplorer.org/dotbot, help@moz.com)
   1408 Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)
```