### PR TITLE
Remove unused database tables and columns

### DIFF
--- a/db/migrate/20200526215213_remove_type_taxt_and_type_taxon_id_from_taxa.rb
+++ b/db/migrate/20200526215213_remove_type_taxt_and_type_taxon_id_from_taxa.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveTypeTaxtAndTypeTaxonIdFromTaxa < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :taxa, :type_taxon_id, :integer
+    remove_column :taxa, :type_taxt, :text
+  end
+end

--- a/db/migrate/20200526215518_remove_headline_notes_taxt_from_taxa.rb
+++ b/db/migrate/20200526215518_remove_headline_notes_taxt_from_taxa.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveHeadlineNotesTaxtFromTaxa < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :taxa, :headline_notes_taxt, :text
+  end
+end

--- a/db/migrate/20200526215649_remove_citation_from_references.rb
+++ b/db/migrate/20200526215649_remove_citation_from_references.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveCitationFromReferences < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :references, :citation, :text
+  end
+end

--- a/db/migrate/20200526221743_drop_changes_and_taxon_states_tables.rb
+++ b/db/migrate/20200526221743_drop_changes_and_taxon_states_tables.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class DropChangesAndTaxonStatesTables < ActiveRecord::Migration[6.0]
+  def up
+    drop_table :changes
+    drop_table :taxon_states
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_215213) do
+ActiveRecord::Schema.define(version: 2020_05_26_215518) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "trackable_id"
@@ -284,7 +284,6 @@ ActiveRecord::Schema.define(version: 2020_05_26_215213) do
     t.string "incertae_sedis_in"
     t.integer "species_id"
     t.integer "protonym_id", null: false
-    t.text "headline_notes_taxt"
     t.integer "subgenus_id"
     t.boolean "hong", default: false, null: false
     t.integer "name_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_215518) do
+ActiveRecord::Schema.define(version: 2020_05_26_215649) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "trackable_id"
@@ -231,7 +231,6 @@ ActiveRecord::Schema.define(version: 2020_05_26_215518) do
     t.text "public_notes"
     t.text "taxonomic_notes"
     t.text "title", null: false
-    t.text "citation"
     t.integer "nesting_reference_id"
     t.string "author_names_suffix"
     t.string "review_state", default: "none", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_160135) do
+ActiveRecord::Schema.define(version: 2020_05_26_215213) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "trackable_id"
@@ -284,7 +284,6 @@ ActiveRecord::Schema.define(version: 2020_05_26_160135) do
     t.string "incertae_sedis_in"
     t.integer "species_id"
     t.integer "protonym_id", null: false
-    t.text "type_taxt"
     t.text "headline_notes_taxt"
     t.integer "subgenus_id"
     t.boolean "hong", default: false, null: false
@@ -299,7 +298,6 @@ ActiveRecord::Schema.define(version: 2020_05_26_160135) do
     t.boolean "auto_generated", default: false, null: false
     t.string "origin"
     t.integer "hol_id"
-    t.integer "type_taxon_id"
     t.boolean "collective_group_name", default: false, null: false
     t.boolean "original_combination", default: false, null: false
     t.integer "subspecies_id"
@@ -319,7 +317,6 @@ ActiveRecord::Schema.define(version: 2020_05_26_160135) do
     t.index ["subspecies_id"], name: "fk_taxa__subspecies_id__taxa__id"
     t.index ["tribe_id"], name: "taxa_tribe_id_idx"
     t.index ["type"], name: "taxa_type_idx"
-    t.index ["type_taxon_id"], name: "fk_taxa__type_taxon_id__taxa__id"
   end
 
   create_table "taxon_history_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
@@ -447,7 +444,6 @@ ActiveRecord::Schema.define(version: 2020_05_26_160135) do
   add_foreign_key "taxa", "taxa", column: "subgenus_id", name: "fk_taxa__subgenus_id__taxa__id"
   add_foreign_key "taxa", "taxa", column: "subspecies_id", name: "fk_taxa__subspecies_id__taxa__id"
   add_foreign_key "taxa", "taxa", column: "tribe_id", name: "fk_taxa__tribe_id__taxa__id"
-  add_foreign_key "taxa", "taxa", column: "type_taxon_id", name: "fk_taxa__type_taxon_id__taxa__id"
   add_foreign_key "taxon_history_items", "taxa", column: "taxon_id", name: "fk_taxon_history_items__taxon_id__taxa__id"
   add_foreign_key "type_names", "references", name: "fk_type_names__reference_id__references__id"
   add_foreign_key "type_names", "taxa", column: "taxon_id", name: "fk_type_names__taxon_id__taxa__id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_215649) do
+ActiveRecord::Schema.define(version: 2020_05_26_221743) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "trackable_id"
@@ -41,18 +41,6 @@ ActiveRecord::Schema.define(version: 2020_05_26_215649) do
   create_table "authors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "changes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "approver_id"
-    t.datetime "approved_at"
-    t.string "change_type"
-    t.integer "taxon_id"
-    t.integer "user_id"
-    t.index ["approver_id"], name: "index_changes_on_approver_id"
-    t.index ["taxon_id"], name: "index_changes_on_taxon_id"
   end
 
   create_table "citations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
@@ -325,15 +313,6 @@ ActiveRecord::Schema.define(version: 2020_05_26_215649) do
     t.integer "position", null: false
     t.string "rank"
     t.index ["taxon_id"], name: "index_taxonomic_history_items_on_taxon_id"
-  end
-
-  create_table "taxon_states", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "taxon_id"
-    t.string "review_state"
-    t.boolean "deleted", default: false, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["taxon_id"], name: "taxon_states_taxon_id_idx"
   end
 
   create_table "tooltips", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
Closes #1026.

* `taxa.headline_notes_taxt`
* `references.citation`
* `taxa.type_taxon_id` and `taxa.type_taxt`
* table `taxon_states`
* table `changes`