### PR TITLE
Move forms and notes_taxt to the protonyms table (from citations)

### DIFF
--- a/app/controllers/api/v1/citations_controller.rb
+++ b/app/controllers/api/v1/citations_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class CitationsController < Api::ApiController
-      ATTRIBUTES = [:id, :reference_id, :pages, :forms, :notes_taxt, :created_at, :updated_at]
+      ATTRIBUTES = [:id, :reference_id, :pages, :created_at, :updated_at]
 
       def index
         render json: with_limit(Citation.all).as_json(only: ATTRIBUTES, root: true)

--- a/app/controllers/api/v1/protonyms_controller.rb
+++ b/app/controllers/api/v1/protonyms_controller.rb
@@ -12,10 +12,12 @@ module Api
         :fossil,
         :biogeographic_region,
         :locality,
+        :forms,
         :uncertain_locality,
         :primary_type_information_taxt,
         :secondary_type_information_taxt,
         :type_notes_taxt,
+        :notes_taxt,
         :created_at,
         :updated_at
       ]

--- a/app/controllers/protonyms_controller.rb
+++ b/app/controllers/protonyms_controller.rb
@@ -89,7 +89,7 @@ class ProtonymsController < ApplicationController
     def protonym_params
       params.require(:protonym).permit(
         *ProtonymForm::ATTRIBUTES.map(&:to_sym),
-        authorship_attributes: [:forms, :notes_taxt, :pages, :reference_id],
+        authorship_attributes: [:pages, :reference_id],
         type_name_attributes: [:taxon_id, :fixation_method, :pages, :reference_id]
       )
     end

--- a/app/controllers/taxa_controller.rb
+++ b/app/controllers/taxa_controller.rb
@@ -85,7 +85,7 @@ class TaxaController < ApplicationController
         name_attributes: [:gender],
         protonym_attributes: [
           *ProtonymForm::ATTRIBUTES.map(&:to_sym),
-          { authorship_attributes: [:forms, :notes_taxt, :pages, :reference_id] }
+          { authorship_attributes: [:pages, :reference_id] }
         ]
       )
     end

--- a/app/database_scripts/database_scripts/protonyms_with_notes_taxt.rb
+++ b/app/database_scripts/database_scripts/protonyms_with_notes_taxt.rb
@@ -10,14 +10,14 @@ module DatabaseScripts
     ]
 
     def results
-      Protonym.joins(:authorship).where.not(citations: { notes_taxt: nil }).includes(:name, :authorship)
+      Protonym.where.not(notes_taxt: nil).includes(:name, :authorship)
     end
 
     def render
       as_table do |t|
         t.header 'Protonym', 'notes_taxt', 'notes_type'
         t.rows do |protonym|
-          notes_taxt = protonym.authorship.notes_taxt
+          notes_taxt = protonym.notes_taxt
 
           [
             protonym.decorate.link_to_protonym,
@@ -45,7 +45,7 @@ category: Inline taxt
 tags: [list]
 
 description: >
-  **Table/column:** `citations.notes_taxt` (called "Notes" in the protonym form)
+  **Table/column:** `protonyms.notes_taxt` called "Notes" in the protonym form)
 
 
   This script was mainly added to investigate how we use the different "inline taxt columns".

--- a/app/decorators/protonym_decorator.rb
+++ b/app/decorators/protonym_decorator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProtonymDecorator < Draper::Decorator
-  delegate :locality, :uncertain_locality?, :authorship, :name, :fossil?
+  delegate :locality, :uncertain_locality?, :forms, :authorship, :name, :fossil?
 
   def link_to_protonym
     h.link_to name_with_fossil, h.protonym_path(protonym), class: 'protonym'
@@ -31,7 +31,7 @@ class ProtonymDecorator < Draper::Decorator
 
   def format_pages_and_forms
     string = authorship.pages.dup
-    string << " (#{authorship.forms})" if authorship.forms
+    string << " (#{forms})" if forms
     string
   end
 end

--- a/app/exporters/exporters/antweb/history/protonym_synopsis/protonym_line.rb
+++ b/app/exporters/exporters/antweb/history/protonym_synopsis/protonym_line.rb
@@ -21,6 +21,7 @@ module Exporters
               [
                 protonym_name,
                 authorship(protonym.authorship),
+                (AntwebFormatter.detax(protonym.notes_taxt) if protonym.notes_taxt),
                 ('[sic]' if protonym.sic?),
                 protonym.decorate.format_locality
               ].compact.join(" ").html_safe
@@ -34,11 +35,6 @@ module Exporters
               string = AntwebFormatter.link_to_reference(authorship.reference)
               string << ": "
               string << protonym.decorate.format_pages_and_forms
-
-              if authorship.notes_taxt
-                string << ' ' << AntwebFormatter.detax(authorship.notes_taxt)
-              end
-
               string
             end
         end

--- a/app/forms/protonym_form.rb
+++ b/app/forms/protonym_form.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
-class ProtonymForm
+class ProtonymForm # rubocop:disable Metrics/ClassLength
   include ActiveModel::Model
 
   ATTRIBUTES = %w[
     biogeographic_region
+    forms
     fossil
     locality
     sic
@@ -13,6 +14,7 @@ class ProtonymForm
     primary_type_information_taxt
     secondary_type_information_taxt
     type_notes_taxt
+    notes_taxt
   ]
 
   attr_reader :protonym

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# TODO: [grep:notes_taxt].
 # This class is currently only used in `Protonym`, where the association
 # is called `authorship`. I believe the plan was to use this in more places,
 # say in taxt items, but that never happened. We may want to rename
@@ -12,14 +13,6 @@ class Citation < ApplicationRecord
 
   validates :pages, presence: true
 
-  before_validation :cleanup_taxts
-
-  strip_attributes only: [:notes_taxt, :pages, :forms], replace_newlines: true
+  strip_attributes only: [:pages], replace_newlines: true
   has_paper_trail
-
-  private
-
-    def cleanup_taxts
-      self.notes_taxt = Taxt::Cleanup[notes_taxt]
-    end
 end

--- a/app/models/protonym.rb
+++ b/app/models/protonym.rb
@@ -37,7 +37,7 @@ class Protonym < ApplicationRecord
   scope :order_by_name, -> { joins(:name).order('names.name') }
 
   has_paper_trail
-  strip_attributes only: [:locality, :biogeographic_region], replace_newlines: true
+  strip_attributes only: [:locality, :biogeographic_region, :forms, :notes_taxt], replace_newlines: true
   strip_attributes only: [:primary_type_information_taxt, :secondary_type_information_taxt, :type_notes_taxt]
   trackable parameters: proc { { name: decorate.name_with_fossil } }
 
@@ -69,7 +69,7 @@ class Protonym < ApplicationRecord
 
     string = +''
     string << "#{authorship.reference.keey}, #{authorship.pages} "
-    string << "(#{authorship.forms}) " if authorship.forms
+    string << "(#{forms}) " if forms
     string << formated_locality + ' ' if formated_locality
     string << biogeographic_region if biogeographic_region
     string
@@ -86,5 +86,6 @@ class Protonym < ApplicationRecord
       self.primary_type_information_taxt = Taxt::Cleanup[primary_type_information_taxt]
       self.secondary_type_information_taxt = Taxt::Cleanup[secondary_type_information_taxt]
       self.type_notes_taxt = Taxt::Cleanup[type_notes_taxt]
+      self.notes_taxt = Taxt::Cleanup[notes_taxt]
     end
 end

--- a/app/models/taxt.rb
+++ b/app/models/taxt.rb
@@ -4,13 +4,13 @@
 
 module Taxt
   TAXTABLES = [
-    [Citation,         'citations',           'notes_taxt'],
     [ReferenceSection, 'reference_sections',  'references_taxt'],
     [ReferenceSection, 'reference_sections',  'subtitle_taxt'],
     [ReferenceSection, 'reference_sections',  'title_taxt'],
     [Protonym,         'protonyms',           'primary_type_information_taxt'],
     [Protonym,         'protonyms',           'secondary_type_information_taxt'],
     [Protonym,         'protonyms',           'type_notes_taxt'],
+    [Protonym,         'protonyms',           'notes_taxt'],
     [TaxonHistoryItem, 'taxon_history_items', 'taxt']
   ]
 

--- a/app/models/what_links_here_item.rb
+++ b/app/models/what_links_here_item.rb
@@ -23,6 +23,7 @@ class WhatLinksHereItem
   def owner
     @_owner ||=
       case table
+      # TODO: [grep:notes_taxt] See if we want to remove "citations".
       when "citations"           then Citation.find(id).protonym
       when "protonyms"           then Protonym.find(id)
       when "reference_sections"  then ReferenceSection.find(id).taxon

--- a/app/queries/catalog/advanced_search_query.rb
+++ b/app/queries/catalog/advanced_search_query.rb
@@ -132,7 +132,7 @@ module Catalog
 
       def forms_clause relation
         return relation unless (forms = params[:forms])
-        relation.where('citations.forms LIKE ?', "%#{forms}%")
+        relation.where('protonyms.forms LIKE ?', "%#{forms}%")
       end
   end
 end

--- a/app/services/taxa/collect_references.rb
+++ b/app/services/taxa/collect_references.rb
@@ -26,7 +26,7 @@ module Taxa
         extract_ref_tags(taxt_content)
       end
 
-      # TODO: Include `taxa.protonym.notes_taxt` once it has been moved from the `citations` table.
+      # TODO: [grep:notes_taxt] Include `taxa.protonym.notes_taxt` once it has been moved from the `citations` table.
       def taxt_content
         string = []
         string << taxon.history_items.pluck(:taxt).join

--- a/app/views/catalog/_show/_taxon_description.haml
+++ b/app/views/catalog/_show/_taxon_description.haml
@@ -17,7 +17,7 @@
   =succeed ':' do
     =taxon.authorship_reference.decorate.expandable_reference
   =taxon.protonym.decorate.format_pages_and_forms
-  =Detax[taxon.protonym.authorship.notes_taxt]
+  =Detax[taxon.protonym.notes_taxt]
   =taxon.protonym.decorate.format_locality
   =add_period_if_necessary(taxon.protonym.biogeographic_region)
 

--- a/app/views/catalog/searches/_results.haml
+++ b/app/views/catalog/searches/_results.haml
@@ -22,9 +22,9 @@
         %td
           =decorated_protonym.link_to_protonym
           .small-text
-            -if taxon.protonym.authorship.forms
+            -if taxon.protonym.forms
               =surround "(", ")" do
-                =taxon.protonym.authorship.forms
+                =taxon.protonym.forms
             =decorated_protonym.format_locality
             =add_period_if_necessary(taxon.protonym.biogeographic_region)
 

--- a/app/views/protonyms/_form.haml
+++ b/app/views/protonyms/_form.haml
@@ -75,10 +75,10 @@
 
           %tr
             %td
-              =authorship_fields.label :forms do
+              =f.label :forms do
                 Forms
                 =db_tooltip_icon "forms", scope: :taxa
-            %td=authorship_fields.text_field :forms
+            %td=f.text_field :forms
 
         %tr
           %td
@@ -167,7 +167,7 @@
 
         %tr
           %td=f.label :notes
-          %td=render 'shared/taxt_editor/taxt_editor_template', name: 'protonym[authorship_attributes][notes_taxt]', content: protonym.authorship.notes_taxt, id: :protonym_authorship_notes_taxt
+          %td=render 'shared/taxt_editor/taxt_editor_template', name: 'protonym[notes_taxt]', content: protonym.notes_taxt, id: :protonym_notes_taxt
 
   .row
     .large-6.columns

--- a/app/views/protonyms/histories/_compare_revision_template.haml
+++ b/app/views/protonyms/histories/_compare_revision_template.haml
@@ -4,5 +4,5 @@
 =succeed ':' do
   =protonym.authorship.reference.decorate.expandable_reference
 =protonym.decorate.format_pages_and_forms
-=Detax[protonym.authorship.notes_taxt]
+=Detax[protonym.notes_taxt]
 =protonym.decorate.format_locality

--- a/app/views/protonyms/index.haml
+++ b/app/views/protonyms/index.haml
@@ -30,9 +30,9 @@
             [sic]
         %td=protonym.authorship.reference.decorate.expandable_reference
         %td=protonym.authorship.pages
-        %td=or_dash protonym.authorship.forms
+        %td=or_dash protonym.forms
         %td=protonym.decorate.format_locality
-        %td=or_dash Detax[protonym.authorship.notes_taxt]
+        %td=or_dash Detax[protonym.notes_taxt]
         -if current_user
           %td=protonym.taxa_count
 

--- a/app/views/protonyms/show.haml
+++ b/app/views/protonyms/show.haml
@@ -41,7 +41,7 @@
           %td=@protonym.authorship.pages
         %tr
           %th Forms
-          %td=or_dash @protonym.authorship.forms
+          %td=or_dash @protonym.forms
         -if (type_name = @protonym.type_name)
           %tr
             %th Type name
@@ -66,7 +66,7 @@
           %td=::Types::FormatTypeField[@protonym.type_notes_taxt]
         %tr
           %th Notes
-          %td=or_dash Detax[@protonym.authorship.notes_taxt]
+          %td=or_dash Detax[@protonym.notes_taxt]
 
 -if @protonym.taxa.present?
   .row.margin-bottom

--- a/app/views/taxa/_form/_protonym_section.haml
+++ b/app/views/taxa/_form/_protonym_section.haml
@@ -25,7 +25,7 @@
           %td=protonym.authorship.pages
         %tr
           %td Forms
-          %td=or_dash protonym.authorship.forms
+          %td=or_dash protonym.forms
         -if (type_name = protonym.type_name)
           %tr
             %td Type name
@@ -50,7 +50,7 @@
           %td=::Types::FormatTypeField[protonym.type_notes_taxt]
         %tr
           %td Notes
-          %td=or_dash Detax[protonym.authorship.notes_taxt]
+          %td=or_dash Detax[protonym.notes_taxt]
   -else
     %h5.callout-header Existing protonym (leave blank if you are creating a new protonym)
     %table.unstriped
@@ -109,10 +109,10 @@
           -if taxon.is_a? SpeciesGroupTaxon
             %tr
               %td
-                =label_tag :forms do
+                =protonym_form.label :forms do
                   Forms
                   =db_tooltip_icon "forms", scope: :taxa
-              %td=authorship_form.text_field :forms
+              %td=protonym_form.text_field :forms
 
           %tr
             %td
@@ -144,4 +144,4 @@
 
           %tr
             %td=form.label :notes_taxt, 'Notes'
-            %td=render 'shared/taxt_editor/taxt_editor_template', name: 'taxon[protonym_attributes][authorship_attributes][notes_taxt]', content: taxon.protonym.authorship.notes_taxt, id: :taxon_protonym_attributes_authorship_attributes_notes_taxt
+            %td=render 'shared/taxt_editor/taxt_editor_template', name: 'taxon[protonym_attributes][notes_taxt]', content: taxon.protonym.notes_taxt, id: :taxon_protonym_attributes_notes_taxt

--- a/db/migrate/20200617215602_move_forms_and_notes_taxt_to_protonyms.rb
+++ b/db/migrate/20200617215602_move_forms_and_notes_taxt_to_protonyms.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# TODO: [grep:notes_taxt].
+# TODO: rails g migration RemoveFormsAndNotesTaxtFromCitations
+# ```
+# class RemoveFormsAndNotesTaxtFromCitations < ActiveRecord::Migration[6.0]
+#   def up
+#     remove_column :citations, :notes_taxt, :text
+#     remove_column :citations, :forms, :string
+#   end
+#
+#   def down
+#     add_column :citations, :notes_taxt, :text
+#     add_column :citations, :forms, :string
+#
+#     execute <<~SQL
+#       UPDATE citations
+#         INNER JOIN protonyms ON citations.id = protonyms.authorship_id
+#         SET
+#           citations.forms = protonyms.forms,
+#           citations.notes_taxt = protonyms.notes_taxt;
+#     SQL
+#   end
+# end
+# ```
+class MoveFormsAndNotesTaxtToProtonyms < ActiveRecord::Migration[6.0]
+  def change
+    add_column :protonyms, :forms, :string
+    add_column :protonyms, :notes_taxt, :text
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          UPDATE protonyms
+            INNER JOIN citations ON protonyms.authorship_id = citations.id
+            SET
+              protonyms.forms = citations.forms,
+              protonyms.notes_taxt = citations.notes_taxt;
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_17_215601) do
+ActiveRecord::Schema.define(version: 2020_06_17_215602) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "trackable_id"
@@ -148,6 +148,8 @@ ActiveRecord::Schema.define(version: 2020_06_17_215601) do
     t.string "biogeographic_region"
     t.boolean "uncertain_locality", default: false, null: false
     t.integer "type_name_id"
+    t.string "forms"
+    t.text "notes_taxt"
     t.index ["authorship_id"], name: "index_protonyms_on_authorship_id"
     t.index ["name_id"], name: "protonyms_name_id_idx"
     t.index ["type_name_id"], name: "index_protonyms_on_type_name_id", unique: true

--- a/features/protonyms/manage.feature
+++ b/features/protonyms/manage.feature
@@ -54,7 +54,7 @@ Feature: Manage protonyms
 
     When I follow "Edit"
     And I fill in "protonym_authorship_attributes_pages" with "page 35"
-    And I fill in "protonym_authorship_attributes_forms" with "male"
+    And I fill in "protonym_forms" with "male"
     And I fill in "protonym_locality" with "Lund"
     And I select "Malagasy" from "protonym_biogeographic_region"
     And I press "Save"
@@ -66,7 +66,7 @@ Feature: Manage protonyms
 
     When I follow "Edit"
     Then I fill in "protonym_authorship_attributes_pages" with "page 35"
-    And I fill in "protonym_authorship_attributes_forms" with "male"
+    And I fill in "protonym_forms" with "male"
     And the "protonym_locality" field should contain "Lund"
 
   Scenario: Editing type fields

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -27,8 +27,7 @@ Given("there is a species with biogeographic region {string}") do |biogeographic
 end
 
 Given("there is a species with forms {string}") do |forms|
-  citation = create :citation, forms: forms
-  protonym = create :protonym, :species_group_name, authorship: citation
+  protonym = create :protonym, :species_group_name, forms: forms
   create :species, protonym: protonym
 end
 

--- a/features/step_definitions/protonym_steps.rb
+++ b/features/step_definitions/protonym_steps.rb
@@ -7,8 +7,8 @@ end
 
 Given("there is a genus protonym {string} with pages and form 'page 9, dealate queen'") do |name_string|
   name = create :genus_name, name: name_string
-  citation = create :citation, forms: 'dealate queen', pages: 'page 9'
-  create :protonym, name: name, authorship: citation
+  citation = create :citation, pages: 'page 9'
+  create :protonym, name: name, authorship: citation, forms: 'dealate queen'
 end
 
 When("I pick {string} from the protonym selector") do |name|

--- a/public/api/v1/swagger.yaml
+++ b/public/api/v1/swagger.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 
 info:
-  version: "1.3.0"
+  version: "1.4.0"
   title: AntCat REST API
   description: Read only API to access antcat.org
   contact:
@@ -752,6 +752,12 @@ definitions:
         type: string
       locality:
         type: string
+      forms:
+        type: string
+        description: String describing the forms; no standard format
+      notes_taxt:
+        type: string
+        description: Long field with text and notes
       created_at:
         type: string
         format: date-time
@@ -822,12 +828,6 @@ definitions:
       pages:
         type: string
         description: String describing the page range; no standard format
-      forms:
-        type: string
-        description: String describing the forms; no standard format
-      notes_taxt:
-        type: string
-        description: Long field with text and notes
       created_at:
         type: string
         format: date-time

--- a/spec/controllers/api/v1/citations_controller_spec.rb
+++ b/spec/controllers/api/v1/citations_controller_spec.rb
@@ -6,15 +6,29 @@ describe Api::V1::CitationsController, as: :visitor do
   describe "GET index" do
     specify do
       citation = create :citation
+
       get :index
-      expect(json_response).to eq([citation.as_json(root: true)])
+      expect(json_response).to eq(
+        [
+          {
+            "citation" => {
+              "id" => citation.id,
+              "pages" => citation.pages,
+              "reference_id" => citation.reference.id,
+
+              "created_at" => citation.created_at.as_json,
+              "updated_at" => citation.updated_at.as_json
+            }
+          }
+        ]
+      )
     end
 
     specify { expect(get(:index)).to have_http_status :ok }
   end
 
   describe "GET show" do
-    let!(:citation) { create :citation, forms: 'w.', notes_taxt: 'notes_taxt', pages: "42" }
+    let!(:citation) { create :citation }
 
     specify do
       get :show, params: { id: citation.id }
@@ -22,9 +36,7 @@ describe Api::V1::CitationsController, as: :visitor do
         {
           "citation" => {
             "id" => citation.id,
-            "forms" => 'w.',
-            "notes_taxt" => 'notes_taxt',
-            "pages" => "42",
+            "pages" => citation.pages,
             "reference_id" => citation.reference.id,
 
             "created_at" => citation.created_at.as_json,

--- a/spec/controllers/api/v1/protonyms_controller_spec.rb
+++ b/spec/controllers/api/v1/protonyms_controller_spec.rb
@@ -31,10 +31,12 @@ describe Api::V1::ProtonymsController, as: :visitor do
             "fossil" => protonym.fossil,
             "biogeographic_region" => Protonym::NEARCTIC_REGION,
             "locality" => 'USA',
+            "forms" => protonym.forms,
             "uncertain_locality" => protonym.uncertain_locality,
             "primary_type_information_taxt" => protonym.primary_type_information_taxt,
             "secondary_type_information_taxt" => protonym.secondary_type_information_taxt,
             "type_notes_taxt" => protonym.type_notes_taxt,
+            "notes_taxt" => protonym.notes_taxt,
 
             "created_at" => protonym.created_at.as_json,
             "updated_at" => protonym.updated_at.as_json

--- a/spec/controllers/protonyms_controller_spec.rb
+++ b/spec/controllers/protonyms_controller_spec.rb
@@ -32,13 +32,13 @@ describe ProtonymsController do
         sic: false,
         biogeographic_region: Protonym::NEARCTIC_REGION,
         locality: 'Africa',
+        forms: 'worker',
         primary_type_information_taxt: "primary type information",
         secondary_type_information_taxt: "secondary type information",
         type_notes_taxt: "type notes",
+        notes_taxt: 'see Lasius',
         authorship_attributes: {
           pages: '99',
-          forms: 'worker',
-          notes_taxt: 'see Lasius',
           reference_id: create(:any_reference).id
         }
       }
@@ -58,14 +58,14 @@ describe ProtonymsController do
       expect(protonym.sic).to eq protonym_params[:sic]
       expect(protonym.locality).to eq protonym_params[:locality]
       expect(protonym.biogeographic_region).to eq protonym_params[:biogeographic_region]
+      expect(protonym.forms).to eq protonym_params[:forms]
       expect(protonym.primary_type_information_taxt).to eq protonym_params[:primary_type_information_taxt]
       expect(protonym.secondary_type_information_taxt).to eq protonym_params[:secondary_type_information_taxt]
       expect(protonym.type_notes_taxt).to eq protonym_params[:type_notes_taxt]
+      expect(protonym.notes_taxt).to eq protonym_params[:notes_taxt]
 
       authorship = protonym.authorship
       expect(authorship.pages).to eq protonym_params[:authorship_attributes][:pages]
-      expect(authorship.forms).to eq protonym_params[:authorship_attributes][:forms]
-      expect(authorship.notes_taxt).to eq protonym_params[:authorship_attributes][:notes_taxt]
       expect(authorship.reference_id).to eq protonym_params[:authorship_attributes][:reference_id]
     end
 
@@ -89,13 +89,13 @@ describe ProtonymsController do
         sic: false,
         biogeographic_region: Protonym::NEARCTIC_REGION,
         locality: 'Africa',
+        forms: 'worker',
         primary_type_information_taxt: "primary type information",
         secondary_type_information_taxt: "secondary type information",
         type_notes_taxt: "type notes",
+        notes_taxt: 'see Lasius',
         authorship_attributes: {
           pages: '99',
-          forms: 'worker',
-          notes_taxt: 'see Lasius',
           reference_id: create(:any_reference).id
         }
       }
@@ -109,14 +109,14 @@ describe ProtonymsController do
       expect(protonym.sic).to eq protonym_params[:sic]
       expect(protonym.biogeographic_region).to eq protonym_params[:biogeographic_region]
       expect(protonym.locality).to eq protonym_params[:locality]
+      expect(protonym.forms).to eq protonym_params[:forms]
       expect(protonym.primary_type_information_taxt).to eq protonym_params[:primary_type_information_taxt]
       expect(protonym.secondary_type_information_taxt).to eq protonym_params[:secondary_type_information_taxt]
       expect(protonym.type_notes_taxt).to eq protonym_params[:type_notes_taxt]
+      expect(protonym.notes_taxt).to eq protonym_params[:notes_taxt]
 
       authorship = protonym.authorship
       expect(authorship.pages).to eq protonym_params[:authorship_attributes][:pages]
-      expect(authorship.forms).to eq protonym_params[:authorship_attributes][:forms]
-      expect(authorship.notes_taxt).to eq protonym_params[:authorship_attributes][:notes_taxt]
       expect(authorship.reference_id).to eq protonym_params[:authorship_attributes][:reference_id]
     end
 

--- a/spec/controllers/taxa_controller_spec.rb
+++ b/spec/controllers/taxa_controller_spec.rb
@@ -108,13 +108,13 @@ describe TaxaController do
                 fossil: true,
                 sic: true,
                 locality: "San Francisco",
+                forms: "w.",
                 primary_type_information_taxt: "primary type information",
                 secondary_type_information_taxt: "secondary type information",
                 type_notes_taxt: "type notes",
+                notes_taxt: "notes taxt",
                 authorship_attributes: {
-                  pages: "21 pp.",
-                  forms: "w.",
-                  notes_taxt: "notes taxt"
+                  pages: "21 pp."
                 }
               }
             )
@@ -129,9 +129,11 @@ describe TaxaController do
             expect(protonym.fossil).to eq protonym_attributes[:fossil]
             expect(protonym.sic).to eq protonym_attributes[:sic]
             expect(protonym.locality).to eq protonym_attributes[:locality]
+            expect(protonym.forms).to eq protonym_attributes[:forms]
             expect(protonym.primary_type_information_taxt).to eq protonym_attributes[:primary_type_information_taxt]
             expect(protonym.secondary_type_information_taxt).to eq protonym_attributes[:secondary_type_information_taxt]
             expect(protonym.type_notes_taxt).to eq protonym_attributes[:type_notes_taxt]
+            expect(protonym.notes_taxt).to eq protonym_attributes[:notes_taxt]
           end
 
           it 'sets authorship_attributes' do
@@ -141,8 +143,6 @@ describe TaxaController do
             authorship_attributes = taxon_params[:protonym_attributes][:authorship_attributes]
 
             expect(authorship.pages).to eq authorship_attributes[:pages]
-            expect(authorship.forms).to eq authorship_attributes[:forms]
-            expect(authorship.notes_taxt).to eq authorship_attributes[:notes_taxt]
           end
 
           context 'when `protonym_id` is supplied' do

--- a/spec/decorators/protonym_decorator_spec.rb
+++ b/spec/decorators/protonym_decorator_spec.rb
@@ -33,11 +33,10 @@ describe ProtonymDecorator do
 
   describe "#format_pages_and_forms" do
     context 'when protonym has `forms`' do
-      let(:citation) { build_stubbed :citation, forms: 'w.' }
-      let(:protonym) { build_stubbed :protonym, authorship: citation }
+      let(:protonym) { build_stubbed :protonym, forms: 'w.' }
 
       specify do
-        expect(protonym.decorate.format_pages_and_forms).to eq "#{protonym.authorship.pages} (#{citation.forms})"
+        expect(protonym.decorate.format_pages_and_forms).to eq "#{protonym.authorship.pages} (#{protonym.forms})"
       end
     end
   end

--- a/spec/exporters/exporters/antweb/history/protonym_synopsis/protonym_line_spec.rb
+++ b/spec/exporters/exporters/antweb/history/protonym_synopsis/protonym_line_spec.rb
@@ -8,8 +8,8 @@ describe Exporters::Antweb::History::ProtonymSynopsis::ProtonymLine do
   describe "#call" do
     let(:taxt_taxon) { create :any_taxon }
     let(:protonym) do
-      citation = create :citation, forms: 'w.', notes_taxt: "see {tax #{taxt_taxon.id}}"
-      create :protonym, :uncertain_locality, locality: 'Indonesia (Timor)', authorship: citation
+      create :protonym, :uncertain_locality, locality: 'Indonesia (Timor)',
+        forms: 'w.', notes_taxt: "see {tax #{taxt_taxon.id}}"
     end
 
     specify do

--- a/spec/factories/protonyms.rb
+++ b/spec/factories/protonyms.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
       sequence(:primary_type_information_taxt) { |n| "primary_type_information_taxt #{n}" }
       sequence(:secondary_type_information_taxt) { |n| "secondary_type_information_taxt #{n}" }
       sequence(:type_notes_taxt) { |n| "type_notes_taxt #{n}" }
+      sequence(:notes_taxt) { |n| "notes_taxt #{n}" }
     end
   end
 end

--- a/spec/models/citation_spec.rb
+++ b/spec/models/citation_spec.rb
@@ -15,10 +15,6 @@ describe Citation do
   end
 
   describe 'callbacks' do
-    it { is_expected.to strip_attributes(:notes_taxt, :pages, :forms) }
-
-    it_behaves_like "a taxt column with cleanup", :notes_taxt do
-      subject { build :citation }
-    end
+    it { is_expected.to strip_attributes(:pages) }
   end
 end

--- a/spec/models/protonym_spec.rb
+++ b/spec/models/protonym_spec.rb
@@ -34,7 +34,7 @@ describe Protonym do
   end
 
   describe 'callbacks' do
-    it { is_expected.to strip_attributes(:locality, :biogeographic_region) }
+    it { is_expected.to strip_attributes(:locality, :biogeographic_region, :forms, :notes_taxt) }
     it { is_expected.to strip_attributes(:primary_type_information_taxt, :secondary_type_information_taxt, :type_notes_taxt) }
 
     it_behaves_like "a taxt column with cleanup", :primary_type_information_taxt do
@@ -46,6 +46,10 @@ describe Protonym do
     end
 
     it_behaves_like "a taxt column with cleanup", :type_notes_taxt do
+      subject { build :protonym }
+    end
+
+    it_behaves_like "a taxt column with cleanup", :notes_taxt do
       subject { build :protonym }
     end
   end

--- a/spec/models/references/what_links_here_spec.rb
+++ b/spec/models/references/what_links_here_spec.rb
@@ -36,14 +36,13 @@ describe References::WhatLinksHere do
     describe "tag: `ref`" do
       let(:ref_tag) { "{ref #{reference.id}}" }
 
-      let!(:citation) { create :citation, reference: reference, notes_taxt: ref_tag }
+      let!(:protonym) { create :protonym, notes_taxt: ref_tag }
       let!(:history_item) { create :taxon_history_item, taxt: ref_tag }
       let!(:reference_section) { create :reference_section, title_taxt: ref_tag, subtitle_taxt: ref_tag, references_taxt: ref_tag }
 
       specify do
         expect(what_links_here.all).to match_array [
-          WhatLinksHereItem.new('citations',           :notes_taxt,          citation.id),
-          WhatLinksHereItem.new('citations',           :reference_id,        citation.id),
+          WhatLinksHereItem.new('protonyms',           :notes_taxt,          protonym.id),
           WhatLinksHereItem.new('reference_sections',  :title_taxt,          reference_section.id),
           WhatLinksHereItem.new('reference_sections',  :subtitle_taxt,       reference_section.id),
           WhatLinksHereItem.new('reference_sections',  :references_taxt,     reference_section.id),

--- a/spec/models/taxa/what_links_here_spec.rb
+++ b/spec/models/taxa/what_links_here_spec.rb
@@ -40,12 +40,12 @@ describe Taxa::WhatLinksHere do
       let!(:other_taxon) { create :any_taxon }
 
       before do
-        other_taxon.protonym.authorship.update!(notes_taxt: "{tax #{taxon.id}}")
+        other_taxon.protonym.update!(notes_taxt: "{tax #{taxon.id}}")
       end
 
       specify do
         expect(what_links_here.all).to match_array [
-          WhatLinksHereItem.new('citations', :notes_taxt, other_taxon.protonym.authorship.id)
+          WhatLinksHereItem.new('protonyms', :notes_taxt, other_taxon.protonym.id)
         ]
         expect(what_links_here.all).to match_array what_links_here.taxts
       end
@@ -59,12 +59,12 @@ describe Taxa::WhatLinksHere do
       let!(:other_taxon) { create :any_taxon }
 
       before do
-        other_taxon.protonym.authorship.update!(notes_taxt: "{tax #{taxon.id}}")
+        other_taxon.protonym.update!(notes_taxt: "{tax #{taxon.id}}")
       end
 
       specify do
         expect(what_links_here.all).to match_array [
-          WhatLinksHereItem.new('citations', :notes_taxt, other_taxon.protonym.authorship.id)
+          WhatLinksHereItem.new('protonyms', :notes_taxt, other_taxon.protonym.id)
         ]
         expect(what_links_here.taxts).to match_array what_links_here.taxts
       end

--- a/spec/models/what_links_here_item_spec.rb
+++ b/spec/models/what_links_here_item_spec.rb
@@ -21,13 +21,13 @@ describe WhatLinksHereItem do
   describe '#taxt?' do
     context 'when `what_links_here_item` is a taxt item' do
       specify do
-        expect(described_class.new('citations', :notes_taxt, 999).taxt?).to eq true
         expect(described_class.new('reference_sections', :references_taxt, 999).taxt?).to eq true
         expect(described_class.new('reference_sections', :subtitle_taxt, 999).taxt?).to eq true
         expect(described_class.new('reference_sections', :title_taxt, 999).taxt?).to eq true
         expect(described_class.new('protonyms', :primary_type_information_taxt, 999).taxt?).to eq true
         expect(described_class.new('protonyms', :secondary_type_information_taxt, 999).taxt?).to eq true
         expect(described_class.new('protonyms', :type_notes_taxt, 999).taxt?).to eq true
+        expect(described_class.new('protonyms', :notes_taxt, 999).taxt?).to eq true
         expect(described_class.new('taxon_history_items', :taxt, 999).taxt?).to eq true
       end
     end

--- a/spec/queries/catalog/advanced_search_query_spec.rb
+++ b/spec/queries/catalog/advanced_search_query_spec.rb
@@ -215,10 +215,10 @@ describe Catalog::AdvancedSearchQuery do
 
     describe "searching for forms" do
       it "only returns taxa with those forms" do
-        protonym = create :protonym, :species_group_name, authorship: create(:citation, forms: 'w.q.')
+        protonym = create :protonym, :species_group_name, forms: 'w.q.'
         atta = create :species, protonym: protonym
 
-        protonym = create :protonym, :species_group_name, authorship: create(:citation, forms: 'q.')
+        protonym = create :protonym, :species_group_name, forms: 'q.'
         create :species, protonym: protonym
 
         expect(described_class[forms: 'w.']).to eq [atta]


### PR DESCRIPTION
Closes #851.

Changes:

* Move `citations.forms` to `protonyms.forms`
* Move `citations.notes_taxt` to `protonyms.notes_taxt`


It's not so much that we want to move these columns to the `protonyms` table -- they, and other columns already in the `protonyms` table, need a new table -- but we want to move them *from* the `citations` table.

The `citations` table is currently used only for protonyms, but with this change it lives up to its name and we can start using it in a general way.
