### PR TITLE
Improve empty-checks for database scripts

### DIFF
--- a/app/database_scripts/database_scripts/fossil_protonyms_with_non_fossil_taxa.rb
+++ b/app/database_scripts/database_scripts/fossil_protonyms_with_non_fossil_taxa.rb
@@ -2,6 +2,10 @@
 
 module DatabaseScripts
   class FossilProtonymsWithNonFossilTaxa < DatabaseScript
+    def empty_status
+      DatabaseScripts::EmptyStatus::EXCLUDED_REVERSED
+    end
+
     def results
       Protonym.fossil.joins(:taxa).where(taxa: { fossil: false }).includes(:taxa)
     end

--- a/app/database_scripts/database_scripts/history_items_with_unbalanced_parentheses_braces_or_brackets.rb
+++ b/app/database_scripts/database_scripts/history_items_with_unbalanced_parentheses_braces_or_brackets.rb
@@ -2,6 +2,15 @@
 
 module DatabaseScripts
   class HistoryItemsWithUnbalancedParenthesesBracesOrBrackets < DatabaseScript
+    def empty?
+      !(
+        unbalanced_parentheses.exists? ||
+        unbalanced_curly_braces.exists? ||
+        unbalanced_square_brackets.exists? ||
+        unbalanced_angle_brackets.exists?
+      )
+    end
+
     def unbalanced_parentheses
       TaxonHistoryItem.where(<<~SQL)
         CHAR_LENGTH(taxt) - CHAR_LENGTH( REPLACE ( taxt, '(', '') ) !=

--- a/app/database_scripts/database_scripts/non_fossil_protonyms_with_fossil_taxa.rb
+++ b/app/database_scripts/database_scripts/non_fossil_protonyms_with_fossil_taxa.rb
@@ -2,6 +2,10 @@
 
 module DatabaseScripts
   class NonFossilProtonymsWithFossilTaxa < DatabaseScript
+    def empty_status
+      DatabaseScripts::EmptyStatus::EXCLUDED_REVERSED
+    end
+
     def results
       Protonym.extant.joins(:taxa).where(taxa: { fossil: true }).includes(:taxa)
     end

--- a/app/database_scripts/database_scripts/obsolete_combinations_with_protonyms_not_matching_its_current_taxons_protonym.rb
+++ b/app/database_scripts/database_scripts/obsolete_combinations_with_protonyms_not_matching_its_current_taxons_protonym.rb
@@ -2,6 +2,10 @@
 
 module DatabaseScripts
   class ObsoleteCombinationsWithProtonymsNotMatchingItsCurrentTaxonsProtonym < DatabaseScript
+    def empty_status
+      DatabaseScripts::EmptyStatus::EXCLUDED_REVERSED
+    end
+
     def results
       Taxon.where(type: Rank::SPECIES_GROUP_NAMES).obsolete_combinations.joins(:current_taxon).
         where("taxa.protonym_id <> current_taxons_taxa.protonym_id").

--- a/app/database_scripts/database_scripts/protonym_references_without_pdfs.rb
+++ b/app/database_scripts/database_scripts/protonym_references_without_pdfs.rb
@@ -2,6 +2,10 @@
 
 module DatabaseScripts
   class ProtonymReferencesWithoutPdfs < DatabaseScript
+    def empty_status
+      DatabaseScripts::EmptyStatus::EXCLUDED
+    end
+
     def results
       Reference.where(id: Citation.select(:reference_id)).
         left_outer_joins(:document).where(reference_documents: { id: nil }).

--- a/app/database_scripts/database_scripts/protonyms_with_more_than_one_species_in_the_same_genus.rb
+++ b/app/database_scripts/database_scripts/protonyms_with_more_than_one_species_in_the_same_genus.rb
@@ -2,6 +2,12 @@
 
 module DatabaseScripts
   class ProtonymsWithMoreThanOneSpeciesInTheSameGenus < DatabaseScript
+    def self.record_in_results? protonynm
+      protonynm.taxa.where(type: Rank::SPECIES).joins(:name).
+        group("SUBSTRING_INDEX(names.name, ' ', 1)").
+        having("COUNT(taxa.id) > 1").exists?
+    end
+
     def results
       dups = Species.joins(:name).
         where.not(status: Status::UNAVAILABLE_MISSPELLING).
@@ -32,6 +38,8 @@ tags: []
 
 description: >
   This script is the reverse of %dbscript:SpeciesWithGeneraAppearingMoreThanOnceInItsProtonym
+
+issue_description: This protonym has more than one species in the same genus.
 
 related_scripts:
   - ProtonymsWithMoreThanOneOriginalCombination

--- a/app/database_scripts/database_scripts/protonyms_with_more_than_one_species_in_the_same_genus.rb
+++ b/app/database_scripts/database_scripts/protonyms_with_more_than_one_species_in_the_same_genus.rb
@@ -8,6 +8,10 @@ module DatabaseScripts
         having("COUNT(taxa.id) > 1").exists?
     end
 
+    def empty_status
+      DatabaseScripts::EmptyStatus::EXCLUDED_REVERSED
+    end
+
     def results
       dups = Species.joins(:name).
         where.not(status: Status::UNAVAILABLE_MISSPELLING).

--- a/app/database_scripts/database_scripts/protonyms_with_more_than_one_taxon_with_associated_history_items.rb
+++ b/app/database_scripts/database_scripts/protonyms_with_more_than_one_taxon_with_associated_history_items.rb
@@ -7,6 +7,10 @@ module DatabaseScripts
         Protonyms.taxa_genus_and_subgenus_pair?(protonym.taxa)
     end
 
+    def empty_status
+      DatabaseScripts::EmptyStatus::FALSE_POSITIVES
+    end
+
     def results
       Protonym.distinct.joins(:taxa).
         where(taxa: { id: Taxon.joins(:history_items).select(:id) }).

--- a/app/database_scripts/database_scripts/protonyms_with_more_than_one_terminal_taxon.rb
+++ b/app/database_scripts/database_scripts/protonyms_with_more_than_one_terminal_taxon.rb
@@ -10,6 +10,10 @@ module DatabaseScripts
         )
     end
 
+    def empty_status
+      DatabaseScripts::EmptyStatus::FALSE_POSITIVES
+    end
+
     def results
       Protonym.joins(:taxa).group(:protonym_id).having(<<~SQL, Status::TERMINAL_STATUSES)
         COUNT(CASE WHEN status IN (?) THEN status ELSE NULL END) > 1

--- a/app/database_scripts/database_scripts/protonyms_with_more_than_one_valid_taxon.rb
+++ b/app/database_scripts/database_scripts/protonyms_with_more_than_one_valid_taxon.rb
@@ -7,6 +7,10 @@ module DatabaseScripts
         Protonyms.taxa_genus_and_subgenus_pair?(protonym.taxa)
     end
 
+    def empty_status
+      DatabaseScripts::EmptyStatus::FALSE_POSITIVES
+    end
+
     def results
       Protonym.joins(:taxa).where(taxa: { status: Status::VALID }).group(:protonym_id).having('COUNT(protonym_id) > 1')
     end

--- a/app/database_scripts/database_scripts/protonyms_with_notes_taxt.rb
+++ b/app/database_scripts/database_scripts/protonyms_with_notes_taxt.rb
@@ -2,6 +2,10 @@
 
 module DatabaseScripts
   class ProtonymsWithNotesTaxt < DatabaseScript
+    def empty_status
+      DatabaseScripts::EmptyStatus::NOT_APPLICABLE
+    end
+
     def results
       Protonym.where.not(notes_taxt: nil).includes(:name, :authorship)
     end

--- a/app/database_scripts/database_scripts/protonyms_with_taxa_with_incompatible_statuses.rb
+++ b/app/database_scripts/database_scripts/protonyms_with_taxa_with_incompatible_statuses.rb
@@ -16,6 +16,10 @@ module DatabaseScripts
       )
     end
 
+    def empty_status
+      DatabaseScripts::EmptyStatus::FALSE_POSITIVES
+    end
+
     def results
       Protonym.joins(:taxa).group(:protonym_id).having(<<~SQL, TYPES)
         COUNT(CASE WHEN status IN (?) THEN status ELSE NULL END) > 1

--- a/app/database_scripts/database_scripts/protonyms_with_type_notes_taxt.rb
+++ b/app/database_scripts/database_scripts/protonyms_with_type_notes_taxt.rb
@@ -2,6 +2,10 @@
 
 module DatabaseScripts
   class ProtonymsWithTypeNotesTaxt < DatabaseScript
+    def empty_status
+      DatabaseScripts::EmptyStatus::NOT_APPLICABLE
+    end
+
     def results
       Protonym.where.not(type_notes_taxt: nil)
     end

--- a/app/database_scripts/database_scripts/reference_documents_with_weird_actual_urls.rb
+++ b/app/database_scripts/database_scripts/reference_documents_with_weird_actual_urls.rb
@@ -2,6 +2,10 @@
 
 module DatabaseScripts
   class ReferenceDocumentsWithWeirdActualUrls < DatabaseScript
+    def empty_status
+      DatabaseScripts::EmptyStatus::EXCLUDED
+    end
+
     def results
       broken_ids = ReferenceDocument.where.not(file_file_name: ['', nil]).to_a.reject do |document|
         document.url.blank? || (document.url == document.__send__(:url_via_file_file_name))

--- a/app/database_scripts/database_scripts/references_with_author_names_suffixes.rb
+++ b/app/database_scripts/database_scripts/references_with_author_names_suffixes.rb
@@ -2,6 +2,10 @@
 
 module DatabaseScripts
   class ReferencesWithAuthorNamesSuffixes < DatabaseScript
+    def empty_status
+      DatabaseScripts::EmptyStatus::NOT_APPLICABLE
+    end
+
     def results
       Reference.order_by_author_names_and_year.where.not(author_names_suffix: [nil, ''])
     end

--- a/app/database_scripts/database_scripts/references_with_blank_pdf_urls_and_filenames.rb
+++ b/app/database_scripts/database_scripts/references_with_blank_pdf_urls_and_filenames.rb
@@ -2,6 +2,10 @@
 
 module DatabaseScripts
   class ReferencesWithBlankPdfUrlsAndFilenames < DatabaseScript
+    def empty_status
+      DatabaseScripts::EmptyStatus::EXCLUDED
+    end
+
     def results
       Reference.joins(:document).where(
         reference_documents: {

--- a/app/database_scripts/database_scripts/references_with_less_parsable_pagination.rb
+++ b/app/database_scripts/database_scripts/references_with_less_parsable_pagination.rb
@@ -5,6 +5,10 @@ module DatabaseScripts
     LIMIT = 150
     ROMAN_NUMERALS = 'ivxlcdm'
 
+    def empty_status
+      DatabaseScripts::EmptyStatus::FALSE_POSITIVES
+    end
+
     def article_results
       ArticleReference.
         where.not('pagination REGEXP ?', "^[0-9]+(-[0-9]+)?$").

--- a/app/database_scripts/database_scripts/references_with_pdfs_not_hosted_by_us.rb
+++ b/app/database_scripts/database_scripts/references_with_pdfs_not_hosted_by_us.rb
@@ -2,6 +2,10 @@
 
 module DatabaseScripts
   class ReferencesWithPdfsNotHostedByUs < DatabaseScript
+    def empty_status
+      DatabaseScripts::EmptyStatus::EXCLUDED
+    end
+
     def results
       Reference.left_outer_joins(:document).
         where.not(reference_documents: { url: [nil, ''] }).

--- a/app/database_scripts/database_scripts/references_without_pdfs.rb
+++ b/app/database_scripts/database_scripts/references_without_pdfs.rb
@@ -2,6 +2,10 @@
 
 module DatabaseScripts
   class ReferencesWithoutPdfs < DatabaseScript
+    def empty_status
+      DatabaseScripts::EmptyStatus::EXCLUDED
+    end
+
     def results
       Reference.left_outer_joins(:document).where(reference_documents: { id: nil }).
         order_by_author_names_and_year.

--- a/app/database_scripts/database_scripts/series_volume_issue_investigation.rb
+++ b/app/database_scripts/database_scripts/series_volume_issue_investigation.rb
@@ -2,6 +2,10 @@
 
 module DatabaseScripts
   class SeriesVolumeIssueInvestigation < DatabaseScript
+    def empty_status
+      DatabaseScripts::EmptyStatus::NOT_APPLICABLE
+    end
+
     def results
       ArticleReference.
         limit(10000).

--- a/app/database_scripts/database_scripts/species_group_protonyms_without_biogeographic_regions.rb
+++ b/app/database_scripts/database_scripts/species_group_protonyms_without_biogeographic_regions.rb
@@ -3,7 +3,7 @@
 # TODO: Add validations once script has been cleared.
 module DatabaseScripts
   class SpeciesGroupProtonymsWithoutBiogeographicRegions < DatabaseScript
-    LIMIT = 5000
+    LIMIT = 1000
 
     def statistics
       <<~STR.html_safe
@@ -23,11 +23,13 @@ module DatabaseScripts
       as_table do |t|
         t.header 'Protonym', 'Authorship', 'Locality', 'Suggested bio region'
         t.rows do |protonym|
+          locality = protonym.locality
+
           [
             protonym.decorate.link_to_protonym,
             protonym.author_citation,
-            protonym.locality,
-            country_mappings[protonym.locality]
+            locality,
+            (country_mappings[locality] if locality)
           ]
         end
       end

--- a/app/database_scripts/database_scripts/taxa_with_disagreeing_name_parts.rb
+++ b/app/database_scripts/database_scripts/taxa_with_disagreeing_name_parts.rb
@@ -2,6 +2,16 @@
 
 module DatabaseScripts
   class TaxaWithDisagreeingNameParts < DatabaseScript
+    def empty?
+      !(
+        species_genus_vs_genus_genus.exists? ||
+        subspecies_species_vs_species_species.exists? ||
+        infrasubspecies_genus_vs_species_genus.exists? ||
+        infrasubspecies_species_vs_species_species.exists? ||
+        infrasubspecies_subspecies_vs_subspecies_subspecies.exists?
+      )
+    end
+
     def species_genus_vs_genus_genus
       Species.joins(:name).joins(:genus).
         joins("JOIN names genus_names ON genus_names.id = genera_taxa.name_id").

--- a/app/database_scripts/database_scripts/valid_taxa_with_non_valid_parents.rb
+++ b/app/database_scripts/database_scripts/valid_taxa_with_non_valid_parents.rb
@@ -4,14 +4,25 @@ module DatabaseScripts
   class ValidTaxaWithNonValidParents < DatabaseScript
     def empty?
       !(
-        genus_results.exists? ||
+        genus_subfamily_results.exists? ||
+        genus_tribe_results.exists? ||
+        subgenus_results.exists? ||
         species_results.exists? ||
-        subspecies_results.exists?
+        subspecies_results.exists? ||
+        infrasubspecies_results.exists?
       )
     end
 
-    def genus_results
+    def genus_subfamily_results
       Genus.valid.joins(:subfamily).where.not(subfamilies_taxa: { status: Status::VALID })
+    end
+
+    def genus_tribe_results
+      Genus.valid.joins(:tribe).where.not(tribes_taxa: { status: Status::VALID })
+    end
+
+    def subgenus_results
+      Subgenus.valid.joins(:genus).where.not(genera_taxa: { status: Status::VALID })
     end
 
     def species_results
@@ -22,11 +33,15 @@ module DatabaseScripts
       Subspecies.valid.joins(:species).where.not(species_taxa: { status: Status::VALID })
     end
 
+    def infrasubspecies_results
+      Infrasubspecies.valid.joins(:subspecies).where.not(subspecies_taxa: { status: Status::VALID })
+    end
+
     def render
       as_table do |t|
         t.header 'Genus', 'Genus status', 'Subfamily', 'Subfamily status'
 
-        t.rows(genus_results) do |genus|
+        t.rows(genus_subfamily_results) do |genus|
           [
             taxon_link(genus),
             genus.status,
@@ -35,6 +50,30 @@ module DatabaseScripts
           ]
         end
       end <<
+        as_table do |t|
+          t.header 'Genus', 'Genus status', 'Tribe', 'Tribe status'
+
+          t.rows(genus_tribe_results) do |genus|
+            [
+              taxon_link(genus),
+              genus.status,
+              taxon_link(genus.tribe),
+              genus.tribe.status
+            ]
+          end
+        end <<
+        as_table do |t|
+          t.header 'Subgenus', 'Subgenus status', 'Genus', 'Genus status'
+
+          t.rows(subgenus_results) do |subgenus|
+            [
+              taxon_link(subgenus),
+              subgenus.status,
+              taxon_link(subgenus.genus),
+              subgenus.genus.status
+            ]
+          end
+        end <<
         as_table do |t|
           t.header 'Species', 'Species status', 'Genus', 'Genus status'
 
@@ -56,6 +95,18 @@ module DatabaseScripts
               subspecies.status,
               taxon_link(subspecies.species),
               subspecies.species.status
+            ]
+          end
+        end <<
+        as_table do |t|
+          t.header 'Infrasubspecies', 'Infrasubspecies status', 'Subspecies', 'Subspecies status'
+
+          t.rows(infrasubspecies_results) do |infrasubspecies|
+            [
+              taxon_link(infrasubspecies),
+              infrasubspecies.status,
+              taxon_link(infrasubspecies.subspecies),
+              infrasubspecies.subspecies.status
             ]
           end
         end

--- a/app/database_scripts/database_scripts/valid_taxa_with_non_valid_parents.rb
+++ b/app/database_scripts/database_scripts/valid_taxa_with_non_valid_parents.rb
@@ -2,6 +2,14 @@
 
 module DatabaseScripts
   class ValidTaxaWithNonValidParents < DatabaseScript
+    def empty?
+      !(
+        genus_results.exists? ||
+        species_results.exists? ||
+        subspecies_results.exists?
+      )
+    end
+
     def genus_results
       Genus.valid.joins(:subfamily).where.not(subfamilies_taxa: { status: Status::VALID })
     end

--- a/app/decorators/database_script_decorator.rb
+++ b/app/decorators/database_script_decorator.rb
@@ -43,6 +43,14 @@ class DatabaseScriptDecorator < Draper::Decorator
   end
 
   def empty_status
-    DatabaseScripts::EmptyStatus[database_script]
+    @_empty_status ||= DatabaseScripts::EmptyStatus[database_script]
+  end
+
+  def empty_status_css
+    return unless section == DatabaseScripts::Tagging::REGRESSION_TEST_SECTION
+
+    if empty_status == DatabaseScripts::EmptyStatus::NOT_EMPTY
+      'bold-warning'
+    end
   end
 end

--- a/app/models/database_scripts/empty_status.rb
+++ b/app/models/database_scripts/empty_status.rb
@@ -9,6 +9,7 @@ module DatabaseScripts
       NOT_EMPTY = 'Not empty',
       NOT_APPLICABLE = 'N/A',
       EXCLUDED = 'Excluded (slow/list)',
+      FALSE_POSITIVES = 'Excluded (false positives)',
       UNKNOWN = '??'
     ]
 

--- a/app/models/database_scripts/empty_status.rb
+++ b/app/models/database_scripts/empty_status.rb
@@ -10,6 +10,7 @@ module DatabaseScripts
       NOT_APPLICABLE = 'N/A',
       EXCLUDED = 'Excluded (slow/list)',
       FALSE_POSITIVES = 'Excluded (false positives)',
+      EXCLUDED_REVERSED = 'Excluded (reversed)',
       UNKNOWN = '??'
     ]
 

--- a/app/models/soft_validations.rb
+++ b/app/models/soft_validations.rb
@@ -5,10 +5,11 @@ class SoftValidations
 
   # These scripts do not 100% belong here since scripts are injected to avoid coupling.
   TAXA_DATABASE_SCRIPTS_TO_CHECK = [
+    DatabaseScripts::CurrentTaxonChains,
     DatabaseScripts::ExtantTaxaInFossilGenera,
     DatabaseScripts::FossilTaxaWithNonFossilProtonyms,
     DatabaseScripts::NonFossilTaxaWithFossilProtonyms,
-    # TODO: Update by script and add back: DatabaseScripts::NonOriginalCombinationsWithSameNameAsItsProtonym,
+    DatabaseScripts::NonOriginalCombinationsWithSameNameAsItsProtonym,
     DatabaseScripts::NonValidTaxaWithACurrentTaxonThatIsNotValid,
     DatabaseScripts::NonValidTaxaWithJuniorSynonyms,
     DatabaseScripts::ObsoleteCombinationsWithDifferentFossilStatusThanItsCurrentTaxon,
@@ -30,6 +31,7 @@ class SoftValidations
     DatabaseScripts::OrphanedProtonyms,
     DatabaseScripts::ProtonymsWithDuplicatedTaxa,
     DatabaseScripts::ProtonymsWithMoreThanOneOriginalCombination,
+    DatabaseScripts::ProtonymsWithMoreThanOneSpeciesInTheSameGenus,
     DatabaseScripts::ProtonymsWithMoreThanOneSynonym,
     DatabaseScripts::ProtonymsWithMoreThanOneTaxonWithAssociatedHistoryItems,
     DatabaseScripts::ProtonymsWithMoreThanOneValidTaxon,

--- a/app/views/database_scripts/index.haml
+++ b/app/views/database_scripts/index.haml
@@ -6,7 +6,7 @@
 
 -content_for :breadcrumbs_right do
   -unless @check_if_empty
-    =link_to "Show empty/not", database_scripts_path(check_if_empty: 'yes'), class: "btn-normal"
+    =link_to "Show empty", database_scripts_path(check_if_empty: 'yes'), class: "btn-normal"
 
 .row
   .small-12.columns
@@ -88,7 +88,7 @@
                   %span.hidden-sort Yes
                   =antcat_icon("check")
               -if @check_if_empty
-                %td.shrink=decorated.empty_status
+                %td.shrink{class: decorated.empty_status_css}=decorated.empty_status
 
 .row
   .small-12.columns


### PR DESCRIPTION
Improve empty-checks for the "Show empty" button by filtering out more false positives and highlighting regression-tests that are not empty.