### PR TITLE
Create fewer PaperTrail versions by explicitly updating reference caches

### DIFF
--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -52,6 +52,7 @@ class ReferenceForm
         set_publisher if reference.is_a? ::BookReference
 
         reference.attributes = params.except(*VIRTUAL_ATTRIBUTES)
+        reference.refresh_author_names_cache
         cleanup_bolton_key
 
         # Raise if there are errors, since `#save!` clears errors before validating.

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -95,7 +95,7 @@ class ReferenceForm
 
       # TODO: Clearing author names creates more `PaperTrail::Version` than needed, but
       # `reference_author_names.position` was not being reset when this was removed. See specs.
-      reference.author_names.clear
+      reference.author_names.destroy_all
       params[:author_names] = author_names
     end
 

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -129,6 +129,5 @@ class ReferenceForm
       errors.add POSSIBLE_DUPLICATE_ERROR_KEY, <<~MSG.html_safe
         This may be a duplicate of #{duplicate.key_with_citation_year} (##{duplicate.id}).<br> To save, click "Save".
       MSG
-      true
     end
 end

--- a/app/models/author_name.rb
+++ b/app/models/author_name.rb
@@ -35,7 +35,7 @@ class AuthorName < ApplicationRecord
 
     def invalidate_reference_caches
       references.reload.find_each do |reference|
-        reference.refresh_author_names_cache
+        reference.refresh_author_names_cache!
         References::Cache::Invalidate[reference]
       end
     end

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -15,7 +15,7 @@ class Reference < ApplicationRecord
   delegate :routed_url, :downloadable?, to: :document, allow_nil: true
   delegate :key_with_citation_year, :key_with_year, to: :key
 
-  has_many :reference_author_names, -> { order(:position) }, dependent: :destroy
+  has_many :reference_author_names, -> { order(:position) }, inverse_of: :reference, dependent: :destroy
   has_many :author_names, -> { order('reference_author_names.position') }, through: :reference_author_names,
     after_add: :refresh_author_names_cache, after_remove: :refresh_author_names_cache
   has_many :authors, through: :author_names

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -16,8 +16,7 @@ class Reference < ApplicationRecord
   delegate :key_with_citation_year, :key_with_year, to: :key
 
   has_many :reference_author_names, -> { order(:position) }, inverse_of: :reference, dependent: :destroy
-  has_many :author_names, -> { order('reference_author_names.position') }, through: :reference_author_names,
-    after_add: :refresh_author_names_cache!, after_remove: :refresh_author_names_cache!
+  has_many :author_names, -> { order('reference_author_names.position') }, through: :reference_author_names
   has_many :authors, through: :author_names
   has_many :nestees, class_name: "Reference", foreign_key: :nesting_reference_id, dependent: :restrict_with_error
   has_many :citations, dependent: :restrict_with_error
@@ -64,11 +63,11 @@ class Reference < ApplicationRecord
   end
 
   # TODO: Probably get rid of this and `#refresh_author_names_cache!`.
-  def refresh_author_names_cache *_args
+  def refresh_author_names_cache
     self.author_names_string_cache = author_names.map(&:name).join('; ').strip
   end
 
-  def refresh_author_names_cache! *_args
+  def refresh_author_names_cache!
     refresh_author_names_cache
     save!(validate: false)
   end

--- a/app/models/reference_author_name.rb
+++ b/app/models/reference_author_name.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class ReferenceAuthorName < ApplicationRecord
-  belongs_to :reference
-  belongs_to :author_name
+  belongs_to :reference, inverse_of: :reference_author_names
+  belongs_to :author_name, inverse_of: :reference_author_names
 
   before_save :invalidate_reference_caches
   before_destroy :invalidate_reference_caches

--- a/app/models/reference_author_name.rb
+++ b/app/models/reference_author_name.rb
@@ -4,16 +4,6 @@ class ReferenceAuthorName < ApplicationRecord
   belongs_to :reference, inverse_of: :reference_author_names
   belongs_to :author_name, inverse_of: :reference_author_names
 
-  before_save :invalidate_reference_caches
-  before_destroy :invalidate_reference_caches
-
   acts_as_list scope: :reference
   has_paper_trail
-
-  private
-
-    def invalidate_reference_caches
-      reference.reload
-      References::Cache::Invalidate[reference]
-    end
 end

--- a/app/observers/reference_document_observer.rb
+++ b/app/observers/reference_document_observer.rb
@@ -2,7 +2,7 @@
 
 class ReferenceDocumentObserver < ActiveRecord::Observer
   def before_update reference_document
-    to_invalidate = reference_document&.reference
-    References::Cache::Invalidate[to_invalidate] if to_invalidate
+    return unless (reference = reference_document&.reference)
+    References::Cache::Invalidate[reference]
   end
 end

--- a/spec/factories/references.rb
+++ b/spec/factories/references.rb
@@ -13,14 +13,8 @@ FactoryBot.define do
       if evaluator.author_names.present?
         reference.author_names = evaluator.author_names
       else
-        # To make sure we're not adding author names when explicitly passed as an empty array.
-        # It's not a super important check, and it's required since `valuator.author_names`
-        # is passed as an empty array if nothing is specified.
+        # Raise to make sure we're not adding author names by mistake in case an empty array is explicitly passes.
         raise 'author_names cannot be empty' if evaluator.__override_names__.include?(:author_names)
-
-        def reference.refresh_author_names_cache *args
-          # No-op.
-        end
 
         author_names = build_stubbed_list(:author_name, 1)
         author_names.each { |author_name| reference.association(:author_names).add_to_target(author_name) }

--- a/spec/forms/reference_form_spec.rb
+++ b/spec/forms/reference_form_spec.rb
@@ -78,10 +78,7 @@ describe ReferenceForm do
             }
           end
 
-          # TODO: Code was changed to make the spec pass, but that introduced a regression where
-          # the `reference_author_names.position` was not reset (which `reference.author_names.clear` did).
-          # See also "reversing author names".
-          xit "creates a single version for the reference" do
+          it "creates a single version for the reference" do
             with_versioning do
               expect { described_class.new(reference, params).save }.
                 to change { reference.versions.count }.by(1)
@@ -95,9 +92,7 @@ describe ReferenceForm do
           end
         end
 
-        # TODO: Spec was added after a regression was introduced.
-        # See also "creates a single version for the reference".
-        describe "reordering author names" do
+        describe "reordering author names (regression test)" do
           let!(:author_names) do
             [
               create(:author_name, name: "Batiatus, B."),
@@ -105,7 +100,7 @@ describe ReferenceForm do
             ]
           end
           let!(:reference) { create :article_reference, author_names: author_names }
-          # TODO: Being extra explicit here since the class mutates the `params`.
+          # TODO: Being extra explicit here since the class mutates `params`.
           let(:original_author_names_string) { 'Batiatus, B.; Glaber, G.' }
           let(:reversed_author_names_string) { 'Glaber, G.; Batiatus, B.' }
           let(:reverse_authors_params) do
@@ -137,8 +132,7 @@ describe ReferenceForm do
             }
           end
 
-          # TODO: We may want this. See `after_add: :refresh_author_names_caches`.
-          xit "creates a single version for the reference" do
+          it "creates a single version for the reference" do
             with_versioning do
               expect { described_class.new(reference, params).save }.
                 to change { reference.versions.count }.by(1)

--- a/spec/forms/reference_form_spec.rb
+++ b/spec/forms/reference_form_spec.rb
@@ -139,6 +139,20 @@ describe ReferenceForm do
             end
           end
 
+          it "creates 'create' versions for the added `ReferenceAuthorName`s" do
+            with_versioning do
+              expect { described_class.new(reference, params).save }.
+                to change { PaperTrail::Version.where(item_type: 'ReferenceAuthorName', event: "create").count }.by(3)
+            end
+          end
+
+          it "creates 'destroy' versions for the removed `ReferenceAuthorName`s" do
+            with_versioning do
+              expect { described_class.new(reference, params).save }.
+                to change { PaperTrail::Version.where(item_type: 'ReferenceAuthorName', event: "destroy").count }.by(1)
+            end
+          end
+
           it "updates `#author_names_string_cache`" do
             expect { described_class.new(reference, params).save }.
               to change { reference.reload.author_names_string_cache }.

--- a/spec/models/reference_author_name_spec.rb
+++ b/spec/models/reference_author_name_spec.rb
@@ -4,35 +4,4 @@ require 'rails_helper'
 
 describe ReferenceAuthorName do
   it { is_expected.to be_versioned }
-
-  describe 'callbacks' do
-    describe '#invalidate_reference_caches' do
-      let!(:reference) { create :any_reference, :with_author_name }
-      let!(:reference_author_names) { reference.reference_author_names.first }
-
-      before do
-        References::Cache::Regenerate[reference]
-      end
-
-      context "when a `ReferenceAuthorName` is added" do
-        it "invalidates caches for its references" do
-          expect { reference.reference_author_names.create!(author_name: create(:author_name)) }.
-            to change { reference.reload.plain_text_cache }.to(nil)
-        end
-      end
-
-      context "when a `ReferenceAuthorName` is updated" do
-        it "invalidates caches for its references" do
-          expect { reference_author_names.update!(position: 999) }.
-            to change { reference.reload.plain_text_cache }.to(nil)
-        end
-      end
-
-      context "when a `ReferenceAuthorName` is destroyed" do
-        it "invalidates caches for its references" do
-          expect { reference_author_names.destroy! }.to change { reference.reload.plain_text_cache }.to(nil)
-        end
-      end
-    end
-  end
 end

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -155,45 +155,6 @@ describe Reference do
         expect(reference.author_names_string).to eq 'Fisher, B.L.; Ward, P.S.'
       end
     end
-
-    describe "updating author names" do
-      context "when an author name is added" do
-        let(:reference) { create :any_reference, author_names: [fisher] }
-
-        it "updates its `author_names_string`" do
-          reference.author_names << ward
-          expect(reference.author_names_string).to eq 'Fisher, B.L.; Ward, P.S.'
-        end
-
-        it "maintains the order in which they were added" do
-          wilden = create :author_name, name: 'Wilden'
-          reference.author_names << wilden
-          reference.author_names << ward
-
-          expect(reference.author_names_string).to eq 'Fisher, B.L.; Wilden; Ward, P.S.'
-        end
-      end
-
-      context "when an author_name is removed" do
-        let(:reference) { create :any_reference, author_names: [fisher, ward] }
-
-        it "updates its `author_names_string`" do
-          expect { reference.author_names.delete(ward) }.
-            to change { reference.reload.author_names_string }.
-            from('Fisher, B.L.; Ward, P.S.').to('Fisher, B.L.')
-        end
-      end
-
-      context "when an author name is changed" do
-        let(:reference) { create :any_reference, author_names: [ward] }
-
-        it "updates its `author_names_string`" do
-          expect { ward.update!(name: 'Fisher') }.
-            to change { reference.reload.author_names_string }.
-            from('Ward, P.S.').to('Fisher')
-        end
-      end
-    end
   end
 
   describe "#author_names_string_with_suffix" do

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -208,4 +208,20 @@ describe Reference do
       end
     end
   end
+
+  describe "#refresh_author_names_cache!" do
+    context "when an author name is added" do
+      let(:fisher) { create :author_name, name: 'Fisher, B.L.' }
+      let(:ward) { create :author_name, name: 'Ward, P.S.' }
+      let(:reference) { create :any_reference, author_names: [fisher] }
+
+      it "updates its `author_names_string`" do
+        reference.author_names << ward
+
+        expect { reference.refresh_author_names_cache! }.
+          to change { reference.reload.author_names_string }.
+          from('Fisher, B.L.').to('Fisher, B.L.; Ward, P.S.')
+      end
+    end
+  end
 end

--- a/spec/observers/reference_observer_spec.rb
+++ b/spec/observers/reference_observer_spec.rb
@@ -41,7 +41,7 @@ describe ReferenceObserver do
         expect(nesting_reference.plain_text_cache).not_to eq nil
         expect(nested_reference.plain_text_cache).not_to eq nil
 
-        nesting_reference.reference_author_names.first.update!(position: 4)
+        nesting_reference.update!(title: "New Title")
 
         expect(nesting_reference.reload.plain_text_cache).to eq nil
         expect(nested_reference.reload.plain_text_cache).to eq nil


### PR DESCRIPTION
Easier to work with since `after_add` and `after_remove` trigger saves for new reference records, which has causes issues for a long time.