### PR TITLE
Add button for restarting and reindexing Solr

### DIFF
--- a/app/controllers/editors_panels/restart_and_reindex_solrs_controller.rb
+++ b/app/controllers/editors_panels/restart_and_reindex_solrs_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module EditorsPanels
+  class RestartAndReindexSolrsController < ApplicationController
+    before_action :ensure_user_is_superadmin
+
+    def create
+      RestartAndReindexSolr[]
+
+      redirect_to editors_panel_path,
+        notice: 'Solr is being restarted and reindexed in the background. It may take a minute or two.'
+    end
+  end
+end

--- a/app/services/restart_and_reindex_solr.rb
+++ b/app/services/restart_and_reindex_solr.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# HACK: Very "hmm", but OK as long as we're only running a single server app server instance.
+class RestartAndReindexSolr
+  include Service
+
+  SCRIPT_PATH = "./script/solr/restart_and_reindex"
+
+  def call
+    return if Rails.env.test?
+
+    $stdout.puts "Executing '#{SCRIPT_PATH}' in a new process..."
+    Process.fork { system(restart_and_reindex_command) }
+  end
+
+  private
+
+    def restart_and_reindex_command
+      @_restart_and_reindex_command ||= "#{SCRIPT_PATH} #{Rails.env}"
+    end
+end

--- a/app/views/editors_panels/index.haml
+++ b/app/views/editors_panels/index.haml
@@ -74,6 +74,8 @@
     %ul
       %li=link_to "Bolton keys to ref tags", bolton_keys_to_ref_tags_path
       %li=link_to 'Edit tooltips', tooltips_path
+      -if user_is_superadmin?
+        %li=link_to append_superadmin_icon('Restart and reindex Solr'), restart_and_reindex_solrs_path, method: :post, data: { confirm: "Are you sure?" }, class: 'btn-warning btn-tiny'
 
 .row.margin-top
   .medium-12.columns

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,6 +177,7 @@ Rails.application.routes.draw do
     scope module: :editors_panels do
       resources :versions, only: [:index, :show]
       resource :bolton_keys_to_ref_tags, only: [:show, :create]
+      resource :restart_and_reindex_solrs, only: [:create]
     end
   end
 

--- a/spec/controllers/editors_panels/restart_and_reindex_solrs_controller_spec.rb
+++ b/spec/controllers/editors_panels/restart_and_reindex_solrs_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EditorsPanels::RestartAndReindexSolrsController do
+  describe "forbidden actions" do
+    context "when signed in as an editor", as: :editor do
+      specify { expect(post(:create)).to have_http_status :forbidden }
+    end
+  end
+
+  describe "POST create", as: :superadmin do
+    it "calls `RestartAndReindexSolr`" do
+      service = instance_double(RestartAndReindexSolr)
+      allow(RestartAndReindexSolr).to receive(:new).and_return(service)
+      allow(service).to receive(:call)
+
+      post(:create)
+
+      expect(service).to have_received(:call)
+    end
+  end
+end


### PR DESCRIPTION
Add button to the Editor's Panel for restarting and reindexing Solr (superadmins only).

Very "hmm", but OK as long as we're only running a single server app server instance.