### PR TITLE
Split `references.citation_year` into `year` and `year_suffix`

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -9,7 +9,7 @@ class AuthorsController < ApplicationController
 
   def show
     @author = find_author
-    @references = @author.references.order(:citation_year).includes(:document).paginate(page: params[:references_page])
+    @references = @author.references.order_by_suffixed_year.includes(:document).paginate(page: params[:references_page])
     @taxa = @author.described_taxa.order("references.year, references.id").
       includes(:name, protonym: { authorship: :reference }).
       paginate(page: params[:taxa_page])

--- a/app/controllers/my/default_reference_controller.rb
+++ b/app/controllers/my/default_reference_controller.rb
@@ -9,7 +9,7 @@ module My
       References::DefaultReference.set(session, reference)
 
       redirect_back fallback_location: references_path,
-        notice: "#{reference.key_with_citation_year} was successfully set as the default reference."
+        notice: "#{reference.key_with_suffixed_year} was successfully set as the default reference."
     end
 
     private

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -18,7 +18,7 @@ class ReferencesController < ApplicationController
   def new
     @reference = if params[:nesting_reference_id]
                    NestedReference.new(
-                     citation_year: params[:citation_year],
+                     year: params[:year],
                      stated_year: params[:stated_year],
                      pagination: "Pp. XX-XX in:",
                      nesting_reference_id: params[:nesting_reference_id]

--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -72,7 +72,7 @@ class ReferencesController < ApplicationController
       return
     end
 
-    activity_parameters = { name: reference.key_with_citation_year } # Grab key before reference author names are deleted.
+    activity_parameters = { name: reference.key_with_suffixed_year } # Grab key before reference author names are deleted.
 
     if reference.destroy
       reference.create_activity :destroy, current_user, parameters: activity_parameters

--- a/app/database_scripts/database_scripts/citations_with_pages_before_references_pagination.rb
+++ b/app/database_scripts/database_scripts/citations_with_pages_before_references_pagination.rb
@@ -29,7 +29,7 @@ module DatabaseScripts
             protonym.decorate.link_to_protonym,
             protonym.author_citation,
             citation.pages,
-            link_to(reference.key_with_citation_year, reference_path(reference)),
+            link_to(reference.key_with_suffixed_year, reference_path(reference)),
             reference.pagination,
             reference.decorate.pdf_link
           ]

--- a/app/database_scripts/database_scripts/nested_references_with_nested_references.rb
+++ b/app/database_scripts/database_scripts/nested_references_with_nested_references.rb
@@ -25,7 +25,7 @@ module DatabaseScripts
     private
 
       def reference_link reference
-        link_to(reference.key_with_citation_year, reference_path(reference)) + ' ' + reference.pagination
+        link_to(reference.key_with_suffixed_year, reference_path(reference)) + ' ' + reference.pagination
       end
 
       def reference_link_with_type reference

--- a/app/database_scripts/database_scripts/protonym_references_without_pdfs.rb
+++ b/app/database_scripts/database_scripts/protonym_references_without_pdfs.rb
@@ -17,7 +17,7 @@ module DatabaseScripts
         t.header 'Reference'
         t.rows do |reference|
           [
-            link_to(reference.key_with_citation_year, reference_path(reference))
+            link_to(reference.key_with_suffixed_year, reference_path(reference))
           ]
         end
       end

--- a/app/database_scripts/database_scripts/references_with_author_names_suffixes.rb
+++ b/app/database_scripts/database_scripts/references_with_author_names_suffixes.rb
@@ -15,7 +15,7 @@ module DatabaseScripts
         t.header 'Reference', 'author_names_suffix'
         t.rows do |reference|
           [
-            link_to(reference.key_with_citation_year, reference_path(reference)),
+            link_to(reference.key_with_suffixed_year, reference_path(reference)),
             reference.author_names_suffix
           ]
         end

--- a/app/database_scripts/database_scripts/references_with_blank_pdf_urls_and_filenames.rb
+++ b/app/database_scripts/database_scripts/references_with_blank_pdf_urls_and_filenames.rb
@@ -23,7 +23,7 @@ module DatabaseScripts
           reference_document = reference.document
 
           [
-            link_to(reference.key_with_citation_year, reference_path(reference)),
+            link_to(reference.key_with_suffixed_year, reference_path(reference)),
             reference_document.id,
             reference_document.created_at,
             document_versions_link(reference_document)

--- a/app/database_scripts/database_scripts/references_with_less_parsable_pagination.rb
+++ b/app/database_scripts/database_scripts/references_with_less_parsable_pagination.rb
@@ -53,7 +53,7 @@ module DatabaseScripts
         t.header 'Reference', 'Pagination'
         t.rows(table_results) do |reference|
           [
-            link_to(reference.key_with_citation_year, reference_path(reference)),
+            link_to(reference.key_with_suffixed_year, reference_path(reference)),
             reference.pagination
           ]
         end

--- a/app/database_scripts/database_scripts/references_with_pdfs_not_hosted_by_us.rb
+++ b/app/database_scripts/database_scripts/references_with_pdfs_not_hosted_by_us.rb
@@ -19,7 +19,7 @@ module DatabaseScripts
         t.header 'Reference', 'URL', 'Protonym reference?'
         t.rows do |reference|
           [
-            link_to(reference.key_with_citation_year, reference_path(reference)),
+            link_to(reference.key_with_suffixed_year, reference_path(reference)),
             link_to(reference.document.url, reference.document.url),
             ('Yes' if reference.protonyms.any?)
           ]

--- a/app/database_scripts/database_scripts/references_without_bolton_keys.rb
+++ b/app/database_scripts/database_scripts/references_without_bolton_keys.rb
@@ -18,7 +18,7 @@ module DatabaseScripts
         t.rows do |reference|
           [
             reference.id,
-            link_to(reference.key_with_citation_year, reference_path(reference)),
+            link_to(reference.key_with_suffixed_year, reference_path(reference)),
             reference.type
           ]
         end

--- a/app/database_scripts/database_scripts/references_without_pdfs.rb
+++ b/app/database_scripts/database_scripts/references_without_pdfs.rb
@@ -17,7 +17,7 @@ module DatabaseScripts
         t.header 'Reference'
         t.rows do |reference|
           [
-            link_to(reference.key_with_citation_year, reference_path(reference))
+            link_to(reference.key_with_suffixed_year, reference_path(reference))
           ]
         end
       end

--- a/app/database_scripts/database_scripts/series_volume_issue_investigation.rb
+++ b/app/database_scripts/database_scripts/series_volume_issue_investigation.rb
@@ -22,7 +22,7 @@ module DatabaseScripts
         t.header 'Reference', 'series_volume_issue'
         t.rows do |reference|
           [
-            link_to(reference.key_with_citation_year, reference_path(reference)),
+            link_to(reference.key_with_suffixed_year, reference_path(reference)),
             reference.series_volume_issue
           ]
         end

--- a/app/database_scripts/database_scripts/taxa_with_same_name.rb
+++ b/app/database_scripts/database_scripts/taxa_with_same_name.rb
@@ -16,7 +16,7 @@ module DatabaseScripts
         t.rows do |taxon|
           [
             taxon_link(taxon),
-            taxon.authorship_reference.key_with_citation_year,
+            taxon.authorship_reference.key_with_suffixed_year,
             taxon.type,
             taxon.status
           ]

--- a/app/database_scripts/database_scripts/taxa_with_same_name_and_status.rb
+++ b/app/database_scripts/database_scripts/taxa_with_same_name_and_status.rb
@@ -17,7 +17,7 @@ module DatabaseScripts
         t.rows do |taxon|
           [
             taxon_link(taxon),
-            taxon.authorship_reference.key_with_citation_year,
+            taxon.authorship_reference.key_with_suffixed_year,
             taxon.type,
             taxon.status,
             ('Yes' if taxon.unresolved_homonym?)

--- a/app/decorators/reference_decorator.rb
+++ b/app/decorators/reference_decorator.rb
@@ -12,7 +12,7 @@ class ReferenceDecorator < Draper::Decorator
   delegate :plain_text, :expandable_reference, :expanded_reference, to: :reference_formatter
 
   def link_to_reference
-    h.link_to reference.key_with_citation_year, h.reference_path(reference)
+    h.link_to reference.key_with_suffixed_year, h.reference_path(reference)
   end
 
   def format_public_notes

--- a/app/exporters/exporters/antweb/taxon_attributes.rb
+++ b/app/exporters/exporters/antweb/taxon_attributes.rb
@@ -52,7 +52,7 @@ module Exporters
 
         def authorship_html_string
           reference = taxon.authorship_reference
-          tag.span reference.key_with_citation_year, title: reference.decorate.plain_text
+          tag.span reference.key_with_suffixed_year, title: reference.decorate.plain_text
         end
 
         def current_valid_name

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -10,7 +10,6 @@ class ReferenceForm
     :author_names_string,
     :author_names_suffix,
     :bolton_key,
-    :citation_year,
     :date,
     :doi,
     :editor_notes,

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -129,7 +129,7 @@ class ReferenceForm
 
       duplicate = Reference.find(duplicates.first[:match].id)
       errors.add POSSIBLE_DUPLICATE_ERROR_KEY, <<~MSG.html_safe
-        This may be a duplicate of #{duplicate.key_with_citation_year} (##{duplicate.id}).<br> To save, click "Save".
+        This may be a duplicate of #{duplicate.key_with_suffixed_year} (##{duplicate.id}).<br> To save, click "Save".
       MSG
     end
 end

--- a/app/forms/reference_form.rb
+++ b/app/forms/reference_form.rb
@@ -24,6 +24,8 @@ class ReferenceForm
     :stated_year,
     :taxonomic_notes,
     :title,
+    :year,
+    :year_suffix,
     document_attributes: [:id, :file, :url]
   ]
 

--- a/app/helpers/reference_select_helper.rb
+++ b/app/helpers/reference_select_helper.rb
@@ -17,7 +17,7 @@ module ReferenceSelectHelper
                         {
                           title: reference.title,
                           author: reference.author_names_string_with_suffix,
-                          year: reference.citation_year_with_stated_year
+                          year: reference.suffixed_year_with_stated_year
                         }
                       end
 

--- a/app/injectable_formatters/antweb_formatter/reference_link.rb
+++ b/app/injectable_formatters/antweb_formatter/reference_link.rb
@@ -14,7 +14,7 @@ module AntwebFormatter
     private
 
       def reference_link
-        link_to reference.key_with_citation_year.html_safe, reference_url, title: title
+        link_to reference.key_with_suffixed_year.html_safe, reference_url, title: title
       end
 
       def document_links

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -3,6 +3,8 @@
 class Citation < ApplicationRecord
   include OrderByPages
 
+  ICZN_APPLICABILITY_YEAR_RANGE = 1758..9999
+
   belongs_to :reference
 
   # TODO: [grep:notes_taxt].

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -13,7 +13,7 @@ class Reference < ApplicationRecord
   ]
 
   delegate :routed_url, :downloadable?, to: :document, allow_nil: true
-  delegate :key_with_citation_year, :key_with_year, to: :key
+  delegate :key_with_suffixed_year, :key_with_year, to: :key
 
   has_many :reference_author_names, -> { order(:position) }, inverse_of: :reference, dependent: :destroy
   has_many :author_names, -> { order('reference_author_names.position') }, through: :reference_author_names
@@ -41,7 +41,7 @@ class Reference < ApplicationRecord
     :public_notes, :editor_notes, :taxonomic_notes, :title, :date, :stated_year, :year_suffix,
     :series_volume_issue, :doi, :bolton_key, :author_names_suffix
   ], replace_newlines: true
-  trackable parameters: proc { { name: key_with_citation_year } }
+  trackable parameters: proc { { name: key_with_suffixed_year } }
 
   workflow_column :review_state
   workflow do

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -73,8 +73,7 @@ class Reference < ApplicationRecord
   end
 
   # Looks like: '2000a ("2001")' (and simply just the year if `suffixed_year` and `stated_year` are blank).
-  # TODO: Rename to `#suffixed_year_with_stated_year`.
-  def citation_year_with_stated_year
+  def suffixed_year_with_stated_year
     return suffixed_year unless stated_year
     %(#{suffixed_year} ("#{stated_year}"))
   end

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -72,6 +72,7 @@ class Reference < ApplicationRecord
     save!(validate: false)
   end
 
+  # Looks like: '2000a ("2001")' (and simply just the year if `suffixed_year` and `stated_year` are blank).
   # TODO: Rename to `#suffixed_year_with_stated_year`.
   def citation_year_with_stated_year
     return suffixed_year unless stated_year

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -26,6 +26,7 @@ class Reference < ApplicationRecord
   validates :year, :pagination, :title, :author_names, presence: true
   validates :nesting_reference_id, absence: true, unless: -> { is_a?(NestedReference) }
   validates :citation_year, format: { with: /\A\d{4,}[a-z]?\z/, message: "must be a year, followed by an optional lowercase letter" }
+  validates :year_suffix, format: { with: /\A[a-z]\z/, message: "must be blank or a single lowercase letter", allow_nil: true }
   validates :doi, format: { with: /\A[^<>]*\z/ }
   validate :ensure_bolton_key_unique
 
@@ -38,7 +39,7 @@ class Reference < ApplicationRecord
   accepts_nested_attributes_for :document, reject_if: proc { |attrs| attrs['file'].blank? && attrs['url'].blank? }
   has_paper_trail
   strip_attributes only: [
-    :public_notes, :editor_notes, :taxonomic_notes, :title, :date, :stated_year,
+    :public_notes, :editor_notes, :taxonomic_notes, :title, :date, :stated_year, :year_suffix,
     :series_volume_issue, :doi, :bolton_key, :author_names_suffix
   ], replace_newlines: true
   trackable parameters: proc { { name: key_with_citation_year } }

--- a/app/models/references/concerns/searchable.rb
+++ b/app/models/references/concerns/searchable.rb
@@ -17,7 +17,7 @@ module References
           integer(:year)
           text(:author_names_string)
           text(:author_names_string, as: :author_names_string_antcat_text)
-          text(:citation_year)
+          text(:suffixed_year)
           text(:stated_year)
           text(:title)
           # NOTE: Safe navigation for `.name` is for journals/publishers created at the same time as the reference.
@@ -29,7 +29,7 @@ module References
           text(:taxonomic_notes)
           text(:bolton_key)
           text(:authors_for_key) { key.authors_for_key } # To find "et al".
-          string(:citation_year)
+          string(:suffixed_year)
           string(:stated_year)
           string(:doi)
           string(:author_names_string)

--- a/app/models/references/key.rb
+++ b/app/models/references/key.rb
@@ -4,13 +4,12 @@ module References
   class Key
     attr_private_initialize :reference
 
-    # Looks like: "Abdul-Rassoul, Dawah & Othman, 1978b".
+    # Looks like: "Forel, Emery & Mayr, 1878b" (and without the "b" if `suffixed_year` is blank).
     def key_with_suffixed_year
       authors_for_key << ', ' << suffixed_year
     end
 
-    # Normal key: "Bolton, 1885g".
-    # This:       "Bolton, 1885".
+    # Looks like: "Forel, Emery & Mayr, 1878".
     def key_with_year
       authors_for_key << ', ' << year.to_s
     end

--- a/app/models/references/key.rb
+++ b/app/models/references/key.rb
@@ -5,8 +5,9 @@ module References
     attr_private_initialize :reference
 
     # Looks like: "Abdul-Rassoul, Dawah & Othman, 1978b".
+    # TODO: Rename to `#key_with_suffixed_year`.
     def key_with_citation_year
-      authors_for_key << ', ' << citation_year
+      authors_for_key << ', ' << suffixed_year
     end
 
     # Normal key: "Bolton, 1885g".
@@ -28,6 +29,6 @@ module References
 
     private
 
-      delegate :citation_year, :year, :author_names, to: :reference, private: true
+      delegate :year, :suffixed_year, :author_names, to: :reference, private: true
   end
 end

--- a/app/models/references/key.rb
+++ b/app/models/references/key.rb
@@ -5,8 +5,7 @@ module References
     attr_private_initialize :reference
 
     # Looks like: "Abdul-Rassoul, Dawah & Othman, 1978b".
-    # TODO: Rename to `#key_with_suffixed_year`.
-    def key_with_citation_year
+    def key_with_suffixed_year
       authors_for_key << ', ' << suffixed_year
     end
 

--- a/app/queries/references/fulltext_search_light_query.rb
+++ b/app/queries/references/fulltext_search_light_query.rb
@@ -19,14 +19,14 @@ module References
       def search_results
         Reference.search do
           keywords normalized_search_query do
-            fields :title, :author_names_string, :citation_year, :stated_year, :bolton_key, :authors_for_key
+            fields :title, :author_names_string, :suffixed_year, :stated_year, :bolton_key, :authors_for_key
             boost_fields author_names_string: 5.0
-            boost_fields citation_year: 2.0
+            boost_fields suffixed_year: 2.0
           end
 
           order_by :score, :desc
           order_by :author_names_string, :desc
-          order_by :citation_year, :asc
+          order_by :suffixed_year, :asc
           paginate page: 1, per_page: NUM_RESULTS
         end.results
       end

--- a/app/queries/references/fulltext_search_query.rb
+++ b/app/queries/references/fulltext_search_query.rb
@@ -72,7 +72,7 @@ module References
 
           order_by :score, :desc
           order_by :author_names_string, :desc
-          order_by :citation_year, :asc
+          order_by :suffixed_year, :asc
         end.results
       end
 

--- a/app/serializers/api/v1/reference_serializer.rb
+++ b/app/serializers/api/v1/reference_serializer.rb
@@ -7,7 +7,7 @@ module Api
         :id,
         :title,
         :year,
-        :citation_year,
+        :year_suffix,
         :stated_year,
         :date,
         :doi,

--- a/app/serializers/autocomplete/linkable_references_serializer.rb
+++ b/app/serializers/autocomplete/linkable_references_serializer.rb
@@ -11,7 +11,7 @@ module Autocomplete
         {
           id: reference.id,
           author: reference.author_names_string_with_suffix,
-          year: reference.citation_year_with_stated_year,
+          year: reference.suffixed_year_with_stated_year,
           title: reference.decorate.format_title,
           full_pagination: full_pagination(reference),
           bolton_key: bolton_key(reference)

--- a/app/serializers/autocomplete/references_serializer.rb
+++ b/app/serializers/autocomplete/references_serializer.rb
@@ -13,7 +13,7 @@ module Autocomplete
           id: reference.id,
           title: reference.title,
           author: reference.author_names_string_with_suffix,
-          year: reference.citation_year_with_stated_year,
+          year: reference.suffixed_year_with_stated_year,
           url: "/references/#{reference.id}"
         }
       end

--- a/app/services/references/formatted/expandable.rb
+++ b/app/services/references/formatted/expandable.rb
@@ -14,7 +14,7 @@ module References
 
       def call
         # TODO: `tabindex: "0"` is required or tooltips won't stay open even with `data-click-open="true"`.
-        tag.span sanitize(reference.key_with_citation_year),
+        tag.span sanitize(reference.key_with_suffixed_year),
           data: { tooltip: true, allow_html: "true", tooltip_class: "foundation-tooltip" },
           tabindex: "0", title: inner_content.html_safe
       end

--- a/app/services/references/formatted/expanded.rb
+++ b/app/services/references/formatted/expanded.rb
@@ -15,7 +15,7 @@ module References
       def call
         string = author_names_with_links
         string << ' '
-        string << sanitize(reference.citation_year_with_stated_year) << '. '
+        string << sanitize(reference.suffixed_year_with_stated_year) << '. '
         string << link_to(reference.decorate.format_title, reference_path(reference)) << ' '
         string << AddPeriodIfNecessary[sanitize(format_citation)]
         string << ' [online early]' if reference.online_early?

--- a/app/services/references/formatted/plain_text.rb
+++ b/app/services/references/formatted/plain_text.rb
@@ -13,7 +13,7 @@ module References
       def call
         string = sanitize(reference.author_names_string_with_suffix)
         string << ' '
-        string << sanitize(reference.citation_year_with_stated_year) << '. '
+        string << sanitize(reference.suffixed_year_with_stated_year) << '. '
         string << Unitalicize[reference.decorate.format_title] << ' '
         string << AddPeriodIfNecessary[sanitize(format_citation)]
         string

--- a/app/services/references/new_from_copy.rb
+++ b/app/services/references/new_from_copy.rb
@@ -30,7 +30,8 @@ module References
       def basic_fields_and_notes
         [
           :author_names_string_cache,
-          :citation_year,
+          :year,
+          :year_suffix,
           :stated_year,
           :title,
           :pagination,

--- a/app/views/catalog/bolton/_taxon.haml
+++ b/app/views/catalog/bolton/_taxon.haml
@@ -5,7 +5,7 @@
   %span.name{class: BoltonFormatter.taxon_css(taxon)}
     ="#{taxon.name.epithet}."
   =decorated_protonym.name_with_fossil
-  =protonym.authorship_reference.key_with_citation_year
+  =protonym.authorship_reference.key_with_suffixed_year
   =decorated_protonym.format_pages_and_forms
   =decorated_protonym.format_locality
 

--- a/app/views/references/_form.haml
+++ b/app/views/references/_form.haml
@@ -18,11 +18,6 @@
         =db_tooltip_icon :author_names_suffix, scope: :references
       =f.select :author_names_suffix, Reference.distinct.pluck(:author_names_suffix)
     .medium-1.columns
-      =f.label :reference_citation_year do
-        Year
-        =db_tooltip_icon "references.citation_year", scope: :references
-      =f.text_field :citation_year
-    .medium-1.columns
       =f.label :year do
         Year
         =db_tooltip_icon "year", scope: :references

--- a/app/views/references/_form.haml
+++ b/app/views/references/_form.haml
@@ -22,6 +22,16 @@
         Year
         =db_tooltip_icon "references.citation_year", scope: :references
       =f.text_field :citation_year
+    .medium-1.columns
+      =f.label :year do
+        Year
+        =db_tooltip_icon "year", scope: :references
+      =f.text_field :year
+    .medium-1.columns
+      =f.label :year_suffix do
+        Suffix
+        =db_tooltip_icon "year_suffix", scope: :references
+      =f.text_field :year_suffix
     .medium-2.columns
       =f.label :stated_year do
         Stated year

--- a/app/views/references/show.haml
+++ b/app/views/references/show.haml
@@ -56,7 +56,7 @@
           %td=or_dash @reference.pagination
         %tr
           %th Year
-          %td=@reference.citation_year_with_stated_year
+          %td=@reference.suffixed_year_with_stated_year
         %tr
           %th Date
           %td

--- a/app/views/references/show.haml
+++ b/app/views/references/show.haml
@@ -1,4 +1,4 @@
--title "#{Unitalicize[@reference.key_with_citation_year]} - References"
+-title "#{Unitalicize[@reference.key_with_suffixed_year]} - References"
 -breadcrumb :reference, @reference
 
 -content_for :breadcrumbs_right do

--- a/app/views/references/show.haml
+++ b/app/views/references/show.haml
@@ -23,7 +23,7 @@
       #more-dropdown.dropdown-pane{data: { dropdown: 'true', hover: 'true', hover_pane: 'true' }}
         %ul.no-bullet
           -if @reference.is_a?(ArticleReference) || @reference.is_a?(BookReference)
-            %li=link_to "New Nested Reference", new_reference_path(nesting_reference_id: @reference.id, citation_year: @reference.citation_year, stated_year: @reference.stated_year), class: "btn-normal"
+            %li=link_to "New Nested Reference", new_reference_path(nesting_reference_id: @reference.id, year: @reference.year, stated_year: @reference.stated_year), class: "btn-normal"
           %li=link_to "Copy", new_reference_path(reference_to_copy: @reference.id), class: "btn-normal"
           -if user_is_editor?
             %li=link_to "Delete", reference_path(@reference), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn-warning"

--- a/app/views/references/what_links_heres/show.haml
+++ b/app/views/references/what_links_heres/show.haml
@@ -1,10 +1,10 @@
--title "#{Unitalicize[@reference.key_with_citation_year]} - What Links Here"
+-title "#{Unitalicize[@reference.key_with_suffixed_year]} - What Links Here"
 -breadcrumb :reference_what_links_here, @reference
 -noindex_meta_tag
 
 -content_for :javascripts do
   =javascript_include_tag "highlight_text"
 
-=render "shared/what_links_here", what_links_here_items: @what_links_here_items, highlight_text: @reference.key_with_citation_year
+=render "shared/what_links_here", what_links_here_items: @what_links_here_items, highlight_text: @reference.key_with_suffixed_year
 
 =will_paginate @what_links_here_items

--- a/app/views/shared/_default_reference.haml
+++ b/app/views/shared/_default_reference.haml
@@ -1,2 +1,2 @@
 -default_reference = References::DefaultReference.get(session)
-#default-reference{data: { id: default_reference.try(:id), reference_key: default_reference.try(:key_with_citation_year) }, style: 'display: none'}
+#default-reference{data: { id: default_reference.try(:id), reference_key: default_reference.try(:key_with_suffixed_year) }, style: 'display: none'}

--- a/config/breadcrumbs/references.rb
+++ b/config/breadcrumbs/references.rb
@@ -6,7 +6,7 @@ end
 
 crumb :reference do |reference|
   if reference.persisted?
-    link sanitize(reference.key_with_citation_year), reference_path(reference)
+    link sanitize(reference.key_with_suffixed_year), reference_path(reference)
   else
     link "##{reference.id} [deleted]"
   end

--- a/db/migrate/20200914170320_add_year_suffix_to_references.rb
+++ b/db/migrate/20200914170320_add_year_suffix_to_references.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# TODO: Remove `references.citation_year`.
+#   rails g migration RemoveCitationYearFromReferences
+#   remove_column :references, :citation_year, :string
+
+class AddYearSuffixToReferences < ActiveRecord::Migration[6.0]
+  def change
+    add_column :references, :year_suffix, :string, limit: 2
+
+    # Expected: `Reference.where("CONCAT_WS('', year, year_suffix) != citation_year").count # 0`.
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL.squish
+          UPDATE `references`
+            SET year_suffix = NULLIF(SUBSTR(citation_year, 5, 1), '');
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_11_161233) do
+ActiveRecord::Schema.define(version: 2020_09_14_170320) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "trackable_id"
@@ -235,6 +235,7 @@ ActiveRecord::Schema.define(version: 2020_09_11_161233) do
     t.text "expanded_reference_cache"
     t.boolean "online_early", default: false, null: false
     t.string "stated_year"
+    t.string "year_suffix", limit: 2
     t.index ["author_names_string_cache", "citation_year"], name: "references_author_names_string_citation_year_idx", length: { author_names_string_cache: 255 }
     t.index ["created_at"], name: "references_created_at_idx"
     t.index ["id", "type"], name: "index_references_on_id_and_type"

--- a/features/markdown/autocompletion.feature
+++ b/features/markdown/autocompletion.feature
@@ -6,9 +6,9 @@ Feature: Markdown autocompletion
   @skip_ci @search
   Scenario: References markdown autocompletion
     Given these references exist
-      | author       | title                    | citation_year |
-      | Giovanni, S. | Giovanni's Favorite Ants | 1810          |
-      | Joffre, J.   | Joffre's Favorite Ants   | 1810          |
+      | author       | title                    | year |
+      | Giovanni, S. | Giovanni's Favorite Ants | 1810 |
+      | Joffre, J.   | Joffre's Favorite Ants   | 1810 |
     And I am on a page with a textarea with markdown preview and autocompletion
 
     When I fill in "issue_description" with "{rfav"

--- a/features/markdown/markdown.feature
+++ b/features/markdown/markdown.feature
@@ -5,8 +5,8 @@ Feature: Markdown
   Scenario: Using markdown
     Given there is an open issue "Merge 'Giovanni' authors"
     Given this reference exists
-      | author       | citation_year |
-      | Giovanni, S. | 1809          |
+      | author       | year |
+      | Giovanni, S. | 1809 |
 
     When I go to the issue page for "Merge 'Giovanni' authors"
     And I follow "Edit"

--- a/features/markdown/preview.feature
+++ b/features/markdown/preview.feature
@@ -5,8 +5,8 @@ Feature: Preview markdown
 
   Scenario: Previewing references markdown
     Given this reference exists
-      | author       | citation_year |
-      | Giovanni, S. | 1809          |
+      | author       | year |
+      | Giovanni, S. | 1809 |
     And I am on a page with a textarea with markdown preview and autocompletion
 
     When I fill in "issue_description" with "See:" and a markdown link to "Giovanni, 1809"

--- a/features/protonyms/manage.feature
+++ b/features/protonyms/manage.feature
@@ -6,8 +6,8 @@ Feature: Manage protonyms
   Scenario: Adding a protonym with a type name
     Given there is a genus "Atta"
     And these references exist
-      | author   | citation_year |
-      | Batiatus | 2004          |
+      | author   | year |
+      | Batiatus | 2004 |
 
     When I go to the protonyms page
     And I follow "New"

--- a/features/reference_form/add_reference_successfully.feature
+++ b/features/reference_form/add_reference_successfully.feature
@@ -7,19 +7,20 @@ Feature: Add reference
   Scenario: Adding an `ArticleReference`
     When I fill in "reference_author_names_string" with "Ward, B.L.;Bolton, B."
     And I fill in "reference_title" with "A reference title"
-    And I fill in "reference_citation_year" with "1981"
+    And I fill in "reference_year" with "1981"
+    And I fill in "reference_year_suffix" with "f"
     And I fill in "reference_bolton_key" with "Ward, B.L. & Bolton, B., 1981a"
     And I fill in "reference_journal_name" with "Ant Journal"
     And I fill in "reference_series_volume_issue" with "1"
     And I fill in "reference_pagination" with "2"
     And I press "Save"
-    Then I should see "Ward, B.L.; Bolton, B. 1981. A reference title. Ant Journal 1:2"
+    Then I should see "Ward, B.L.; Bolton, B. 1981f. A reference title. Ant Journal 1:2"
     And I should see "Ward B.L. Bolton B. 1981a"
 
   Scenario: Adding a `BookReference`
     When I fill in "reference_author_names_string" with "Ward, B.L.;Bolton, B."
     And I fill in "reference_title" with "A reference title"
-    And I fill in "reference_citation_year" with "1981"
+    And I fill in "reference_year" with "1981"
     And I select the reference tab "#book-tab"
     And I fill in "reference_publisher_string" with "New York: Houghton Mifflin"
     And I fill in "reference_pagination" with "32 pp."
@@ -28,12 +29,12 @@ Feature: Add reference
 
   Scenario: Adding a `NestedReference`
     Given this article reference exists
-      | author     | title          | citation_year | citation   |
-      | Ward, P.S. | Annals of Ants | 2010          | Psyche 1:1 |
+      | author     | title          | year | citation   |
+      | Ward, P.S. | Annals of Ants | 2010 | Psyche 1:1 |
 
     When I fill in "reference_author_names_string" with "Ward, B.L.;Bolton, B."
     And I fill in "reference_title" with "A reference title"
-    And I fill in "reference_citation_year" with "1981"
+    And I fill in "reference_year" with "1981"
     And I select the reference tab "#nested-tab"
     And I fill in "reference_pagination" with "Pp. 32-33 in:"
     And I fill in "reference_nesting_reference_id" with the ID for "Annals of Ants"

--- a/features/reference_form/add_reference_unsuccessfully.feature
+++ b/features/reference_form/add_reference_unsuccessfully.feature
@@ -7,7 +7,7 @@ Feature: Add reference unsuccessfully
   Scenario: Leaving required fields blank (general fields)
     When I fill in "reference_author_names_string" with ""
     And I fill in "reference_title" with ""
-    And I fill in "reference_citation_year" with ""
+    And I fill in "reference_year" with ""
     And I fill in "reference_pagination" with ""
     And I press "Save"
     Then I should see "Author names can't be blank"

--- a/features/reference_form/copy_reference.feature
+++ b/features/reference_form/copy_reference.feature
@@ -9,13 +9,14 @@ Feature: Copy reference
 
   Scenario: Copy an `ArticleReference`
     Given this article reference exists
-      | author     | title          | citation | citation_year  | stated_year |
-      | Ward, P.S. | Annals of Ants | Ants 1:2 | 1910b          | 1911        |
+      | author     | title          | citation | year | year_suffix | stated_year |
+      | Ward, P.S. | Annals of Ants | Ants 1:2 | 1910 | b           | 1911        |
     And I go to the page of the most recent reference
 
     When I follow "Copy"
     Then the "reference_author_names_string" field should contain "Ward, P.S."
-    And the "reference_citation_year" field should contain "1910b"
+    And the "reference_year" field should contain "1910"
+    And the "reference_year_suffix" field should contain "b"
     And the "reference_stated_year" field should contain "1911"
     And the "reference_pagination" field should contain "2"
     And the "reference_journal_name" field should contain "Ants"

--- a/features/reference_form/duplicate_checking.feature
+++ b/features/reference_form/duplicate_checking.feature
@@ -13,10 +13,10 @@ Feature: Checking for duplicates during data entry
     When I go to the references page
     And I follow "New"
     And I fill in "reference_author_names_string" with "Ward, P."
-    And I fill in "reference_title" with "Ants"
-    And I fill in "reference_series_volume_issue" with "6"
     And I fill in "reference_year" with "2010"
+    And I fill in "reference_title" with "Ants"
     And I fill in "reference_journal_name" with "Psyche"
+    And I fill in "reference_series_volume_issue" with "6"
     And I fill in "reference_pagination" with "1"
     And I press "Save"
     Then I should see "This may be a duplicate of Ward, 2010"
@@ -25,13 +25,13 @@ Feature: Checking for duplicates during data entry
     Then I should see "Reference was successfully added"
 
   Scenario: Editing a reference that makes it a duplicate
-    Given this article reference exists
-      | author     | citation   | title            | year |
-      | Bolton, B. | Psyche 5:3 | Ants are my life | 2010 |
+    Given there is an article reference
 
     When I go to the edit page for the most recent reference
     And I fill in "reference_author_names_string" with "Ward, P."
     And I fill in "reference_title" with "Ants"
+    And I fill in "reference_year" with "2010"
+    And I fill in "reference_journal_name" with "Psyche"
     And I fill in "reference_series_volume_issue" with "6:1"
     And I press "Save"
     Then I should see "This may be a duplicate of Ward, 2010"

--- a/features/reference_form/duplicate_checking.feature
+++ b/features/reference_form/duplicate_checking.feature
@@ -6,8 +6,8 @@ Feature: Checking for duplicates during data entry
   Background:
     Given I log in as a helper editor
     And this article reference exists
-      | author   | citation   | title | citation_year |
-      | Ward, P. | Psyche 6:1 | Ants  | 2010          |
+      | author   | citation   | title | year |
+      | Ward, P. | Psyche 6:1 | Ants  | 2010 |
 
   Scenario: Adding a duplicate reference, but saving it anyway
     When I go to the references page
@@ -15,7 +15,7 @@ Feature: Checking for duplicates during data entry
     And I fill in "reference_author_names_string" with "Ward, P."
     And I fill in "reference_title" with "Ants"
     And I fill in "reference_series_volume_issue" with "6"
-    And I fill in "reference_citation_year" with "2010"
+    And I fill in "reference_year" with "2010"
     And I fill in "reference_journal_name" with "Psyche"
     And I fill in "reference_pagination" with "1"
     And I press "Save"
@@ -26,8 +26,8 @@ Feature: Checking for duplicates during data entry
 
   Scenario: Editing a reference that makes it a duplicate
     Given this article reference exists
-      | author     | citation   | title            | citation_year |
-      | Bolton, B. | Psyche 5:3 | Ants are my life | 2010          |
+      | author     | citation   | title            | year |
+      | Bolton, B. | Psyche 5:3 | Ants are my life | 2010 |
 
     When I go to the edit page for the most recent reference
     And I fill in "reference_author_names_string" with "Ward, P."

--- a/features/reference_form/edit_reference_successfully.feature
+++ b/features/reference_form/edit_reference_successfully.feature
@@ -8,7 +8,7 @@ Feature: Edit reference successfully
     When I go to the edit page for the most recent reference
     And I fill in "reference_author_names_string" with ""
     And I fill in "reference_title" with ""
-    And I fill in "reference_citation_year" with ""
+    And I fill in "reference_year" with ""
     And I fill in "reference_pagination" with ""
     And I press "Save"
     Then I should see "Author names can't be blank"
@@ -36,8 +36,8 @@ Feature: Edit reference successfully
 
   Scenario: Change a reference's type
     Given this article reference exists
-      | author     | title | citation   | citation_year |
-      | Fisher, B. | Ants  | Psyche 6:4 | 2010          |
+      | author     | title | citation   | year |
+      | Fisher, B. | Ants  | Psyche 6:4 | 2010 |
 
     When I go to the edit page for the most recent reference
     And I select the reference tab "#book-tab"
@@ -56,11 +56,11 @@ Feature: Edit reference successfully
 
   Scenario: Edit a `NestedReference`
     Given this article reference exists
-      | author     | citation   | citation_year | title |
-      | Ward, P.S. | Psyche 5:3 | 2001          | Ants  |
+      | author     | citation   | year | title |
+      | Ward, P.S. | Psyche 5:3 | 2001 | Ants  |
     And the following entry nests it
-      | author     | title            | citation_year | pagination |
-      | Bolton, B. | Ants are my life | 2001          | In:        |
+      | author     | title            | year | pagination |
+      | Bolton, B. | Ants are my life | 2001 | In:        |
 
     When I go to the references page
     Then I should see "Bolton, B. 2001. Ants are my life. In: Ward, P.S. 2001. Ants. Psyche 5:3"

--- a/features/reference_form/edit_reference_successfully.feature
+++ b/features/reference_form/edit_reference_successfully.feature
@@ -36,8 +36,8 @@ Feature: Edit reference successfully
 
   Scenario: Change a reference's type
     Given this article reference exists
-      | author     | title | citation   | year |
-      | Fisher, B. | Ants  | Psyche 6:4 | 2010 |
+      | author     | title | year |
+      | Fisher, B. | Ants  | 2010 |
 
     When I go to the edit page for the most recent reference
     And I select the reference tab "#book-tab"

--- a/features/reference_form/new_nested_reference_button.feature
+++ b/features/reference_form/new_nested_reference_button.feature
@@ -1,13 +1,13 @@
 Feature: Add new nested reference button
   Scenario: Add new `NestedReference` using the button
     Given this article reference exists
-      | year | stated_year | citation   |
-      | 2010 | 2011        | Psyche 1:1 |
+      | year | stated_year |
+      | 2010 | 2011        |
     And I log in as a helper editor
 
     When I go to the page of the most recent reference
     And I follow "New Nested Reference"
     Then the "reference_year" field should contain "2010"
-    Then the "reference_stated_year" field should contain "2011"
+    And the "reference_stated_year" field should contain "2011"
     And the "reference_pagination" field should contain "Pp. XX-XX in:"
     And nesting_reference_id should contain a valid reference id

--- a/features/reference_form/new_nested_reference_button.feature
+++ b/features/reference_form/new_nested_reference_button.feature
@@ -1,13 +1,13 @@
 Feature: Add new nested reference button
   Scenario: Add new `NestedReference` using the button
     Given this article reference exists
-      | citation_year | stated_year | citation   |
-      | 2010b         | 2011        | Psyche 1:1 |
+      | year | stated_year | citation   |
+      | 2010 | 2011        | Psyche 1:1 |
     And I log in as a helper editor
 
     When I go to the page of the most recent reference
     And I follow "New Nested Reference"
-    Then the "reference_citation_year" field should contain "2010b"
+    Then the "reference_year" field should contain "2010"
     Then the "reference_stated_year" field should contain "2011"
     And the "reference_pagination" field should contain "Pp. XX-XX in:"
     And nesting_reference_id should contain a valid reference id

--- a/features/references/delete_reference.feature
+++ b/features/references/delete_reference.feature
@@ -4,8 +4,8 @@ Feature: Delete reference
 
   Scenario: Delete a reference (with feed)
     Given this reference exists
-      | author | citation_year |
-      | Fisher | 2004          |
+      | author | year |
+      | Fisher | 2004 |
 
     When I go to the page of the most recent reference
     And I follow "Delete"

--- a/features/references/search_references.feature
+++ b/features/references/search_references.feature
@@ -2,9 +2,9 @@ Feature: Searching references
   @search
   Scenario: Searching for an author name with diacritics, using the diacritics in the query
     Given these references exist
-      | author         | title             |
-      | Hölldobler, B. | Hölldobler's Ants |
-      | Fisher, B.     | Fisher's Ants     |
+      | author         |
+      | Hölldobler, B. |
+      | Fisher, B.     |
     And I go to the references page
 
     When I fill in "reference_q" with "Hölldobler" within the desktop menu

--- a/features/step_definitions/advanced_search_steps.rb
+++ b/features/step_definitions/advanced_search_steps.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Given("there is a species described in {int}") do |year|
-  reference = create :any_reference, citation_year: year
+  reference = create :any_reference, year: year
   taxon = create :species
   taxon.protonym.authorship.update!(reference: reference)
 end

--- a/features/step_definitions/reference_steps.rb
+++ b/features/step_definitions/reference_steps.rb
@@ -57,7 +57,8 @@ Given("the following entry nests it") do |table|
   NestedReference.create!(
     title: hsh[:title],
     author_names: [create(:author_name, name: hsh[:author])],
-    citation_year: hsh[:citation_year],
+    year: hsh[:year],
+    year_suffix: hsh[:year_suffix],
     pagination: hsh[:pagination],
     nesting_reference: Reference.last
   )

--- a/features/taxon_form/add_taxon_successfully.feature
+++ b/features/taxon_form/add_taxon_successfully.feature
@@ -2,8 +2,8 @@ Feature: Adding a taxon successfully
   Background:
     Given I log in as a catalog editor named "Archibald"
     And this reference exists
-      | author | citation_year |
-      | Fisher | 2004          |
+      | author | year |
+      | Fisher | 2004 |
     And the default reference is "Fisher, 2004"
 
   @javascript

--- a/features/taxon_form/edit_taxon.feature
+++ b/features/taxon_form/edit_taxon.feature
@@ -3,7 +3,7 @@ Feature: Editing a taxon
     Given I log in as a catalog editor named "Archibald"
 
   @javascript
-  Scenario: Changing the authorship
+  Scenario: Changing protonym
     Given there is a genus "Eciton"
     And there is a genus protonym "Formica" with pages and form 'page 9, dealate queen'
 

--- a/features/taxon_history_items/edit_history_item.feature
+++ b/features/taxon_history_items/edit_history_item.feature
@@ -98,8 +98,8 @@ Feature: Editing a history item
   @javascript
   Scenario: Seeing the markdown preview (and cancelling)
     Given this reference exists
-      | author       | citation_year |
-      | Giovanni, S. | 1809          |
+      | author       | year |
+      | Giovanni, S. | 1809 |
     And there is a genus "Eciton" with a history item "Eciton history," and a markdown link to "Giovanni, 1809"
 
     When I go to the edit page for "Eciton"

--- a/features/widgets/default_reference.feature
+++ b/features/widgets/default_reference.feature
@@ -2,8 +2,8 @@ Feature: Using the default reference
   Background:
     Given I log in as a catalog editor
     And this reference exists
-      | author     | citation_year |
-      | Ward, P.S. | 2010          |
+      | author     | year |
+      | Ward, P.S. | 2010 |
 
   Scenario: Default reference used for new taxon
     Given the Formicidae family exists

--- a/features/widgets/reference_selector.feature
+++ b/features/widgets/reference_selector.feature
@@ -2,10 +2,10 @@ Feature: Reference selector
   Background:
     Given I log in as a catalog editor
     And these references exist
-      | author   | citation_year |
-      | Fisher   | 2004          |
-      | Fisher   | 2004          |
-      | Batiatus | 2004          |
+      | author   | year |
+      | Fisher   | 2004 |
+      | Fisher   | 2004 |
+      | Batiatus | 2004 |
     And there is a subfamily "Formicinae"
 
   @search @javascript

--- a/lib/dev_monkey_patches/ant_cat.rb
+++ b/lib/dev_monkey_patches/ant_cat.rb
@@ -54,7 +54,7 @@ module DevMonkeyPatches
     module Reference
       def dev_dev_link localhost: false
         base_url = localhost ? LOCALHOST_BASE_URL : PRODUCTION_BASE_URL
-        link = +"#{base_url}/references/#{id}?#{key_with_citation_year.tr(' ', '_')}"
+        link = +"#{base_url}/references/#{id}?#{key_with_suffixed_year.tr(' ', '_')}"
 
         def link.open
           `xdg-open "#{self}"`

--- a/public/api/v1/swagger.yaml
+++ b/public/api/v1/swagger.yaml
@@ -899,7 +899,9 @@ definitions:
         type: integer
       date:
         type: string
-      citation_year:
+      year:
+        type: integer
+      year_suffix:
         type: string
       stated_year:
         type: string

--- a/spec/controllers/references/autocompletes_controller_spec.rb
+++ b/spec/controllers/references/autocompletes_controller_spec.rb
@@ -72,7 +72,7 @@ describe References::AutocompletesController do
               "author" => "E.O. Wilson",
               "search_query" => "author:'E.O. Wilson'",
               "title" => reference.title,
-              "year" => reference.suffixed_year,
+              "year" => reference.suffixed_year_with_stated_year,
               "url" => "/references/#{reference.id}"
             }
           ]

--- a/spec/controllers/references/autocompletes_controller_spec.rb
+++ b/spec/controllers/references/autocompletes_controller_spec.rb
@@ -72,7 +72,7 @@ describe References::AutocompletesController do
               "author" => "E.O. Wilson",
               "search_query" => "author:'E.O. Wilson'",
               "title" => reference.title,
-              "year" => reference.citation_year,
+              "year" => reference.suffixed_year,
               "url" => "/references/#{reference.id}"
             }
           ]

--- a/spec/controllers/references_controller_spec.rb
+++ b/spec/controllers/references_controller_spec.rb
@@ -25,6 +25,8 @@ describe ReferencesController do
       {
         title: 'New Ants',
         citation_year: '1999b',
+        year: 1999,
+        year_suffix: 'b',
         stated_year: '2000',
         author_names_string: "Batiatus, B.; Glaber, G.",
         pagination: '5',
@@ -51,8 +53,9 @@ describe ReferencesController do
       reference = Reference.last
       expect(reference.title).to eq reference_params[:title]
       expect(reference.citation_year).to eq reference_params[:citation_year]
+      expect(reference.year).to eq reference_params[:year]
+      expect(reference.year_suffix).to eq reference_params[:year_suffix]
       expect(reference.stated_year).to eq reference_params[:stated_year]
-      expect(reference.year).to eq 1999
 
       expect(reference.author_names_string).to eq reference_params[:author_names_string]
 

--- a/spec/controllers/references_controller_spec.rb
+++ b/spec/controllers/references_controller_spec.rb
@@ -111,7 +111,7 @@ describe ReferencesController do
 
       activity = Activity.last
       expect(activity.edit_summary).to eq 'edited'
-      expect(activity.parameters).to eq(name: reference.key_with_citation_year)
+      expect(activity.parameters).to eq(name: reference.key_with_suffixed_year)
     end
   end
 
@@ -123,7 +123,7 @@ describe ReferencesController do
     end
 
     it 'creates an activity' do
-      reference_key = reference.key_with_citation_year
+      reference_key = reference.key_with_suffixed_year
 
       expect { delete(:destroy, params: { id: reference.id }) }.
         to change { Activity.where(action: :destroy, trackable: reference).count }.by(1)

--- a/spec/controllers/references_controller_spec.rb
+++ b/spec/controllers/references_controller_spec.rb
@@ -24,7 +24,6 @@ describe ReferencesController do
     let!(:reference_params) do
       {
         title: 'New Ants',
-        citation_year: '1999b',
         year: 1999,
         year_suffix: 'b',
         stated_year: '2000',
@@ -52,7 +51,6 @@ describe ReferencesController do
 
       reference = Reference.last
       expect(reference.title).to eq reference_params[:title]
-      expect(reference.citation_year).to eq reference_params[:citation_year]
       expect(reference.year).to eq reference_params[:year]
       expect(reference.year_suffix).to eq reference_params[:year_suffix]
       expect(reference.stated_year).to eq reference_params[:stated_year]

--- a/spec/decorators/activity_decorator_spec.rb
+++ b/spec/decorators/activity_decorator_spec.rb
@@ -56,7 +56,7 @@ describe ActivityDecorator do
 
           specify do
             expect(decorated.did_something.squish).
-              to eq %(edited the reference <a href="/references/#{trackable.id}">#{trackable.key_with_citation_year}</a>)
+              to eq %(edited the reference <a href="/references/#{trackable.id}">#{trackable.key_with_suffixed_year}</a>)
           end
         end
 
@@ -66,7 +66,7 @@ describe ActivityDecorator do
 
           specify do
             expect(decorated.did_something.squish).
-              to eq %(started reviewing the reference <a href="/references/#{trackable.id}">#{trackable.key_with_citation_year}</a>)
+              to eq %(started reviewing the reference <a href="/references/#{trackable.id}">#{trackable.key_with_suffixed_year}</a>)
           end
         end
 
@@ -76,7 +76,7 @@ describe ActivityDecorator do
 
           specify do
             expect(decorated.did_something.squish).
-              to eq %(finished reviewing the reference <a href="/references/#{trackable.id}">#{trackable.key_with_citation_year}</a>)
+              to eq %(finished reviewing the reference <a href="/references/#{trackable.id}">#{trackable.key_with_suffixed_year}</a>)
           end
         end
 
@@ -86,7 +86,7 @@ describe ActivityDecorator do
 
           specify do
             expect(decorated.did_something.squish).
-              to eq %(restarted reviewing the reference <a href="/references/#{trackable.id}">#{trackable.key_with_citation_year}</a>)
+              to eq %(restarted reviewing the reference <a href="/references/#{trackable.id}">#{trackable.key_with_suffixed_year}</a>)
           end
         end
       end

--- a/spec/decorators/author_decorator_spec.rb
+++ b/spec/decorators/author_decorator_spec.rb
@@ -14,7 +14,7 @@ describe AuthorDecorator do
     end
 
     context "when author has references" do
-      let!(:reference) { create :any_reference, author_names: [author_name], citation_year: 2000 }
+      let!(:reference) { create :any_reference, author_names: [author_name], year: 2000 }
 
       context "when start and end year are the same" do
         specify { expect(decorated.published_between).to eq reference.year }
@@ -22,7 +22,7 @@ describe AuthorDecorator do
 
       context "when start and end year are not the same" do
         before do
-          create :any_reference, author_names: [author_name], citation_year: 2010
+          create :any_reference, author_names: [author_name], year: 2010
         end
 
         specify { expect(decorated.published_between).to eq "2000–2010" }
@@ -39,7 +39,7 @@ describe AuthorDecorator do
     end
 
     context "when there are two years" do
-      let!(:reference) { create :any_reference, author_names: [author_name], citation_year: 2000 }
+      let!(:reference) { create :any_reference, author_names: [author_name], year: 2000 }
 
       before do
         create(:species).protonym.authorship.update!(reference: reference)
@@ -51,10 +51,10 @@ describe AuthorDecorator do
 
       context "when start and end year are not the same" do
         before do
-          second_reference = create :any_reference, author_names: [author_name], citation_year: 1990
+          second_reference = create :any_reference, author_names: [author_name], year: 1990
           create(:any_taxon).protonym.authorship.update!(reference: second_reference)
 
-          old_reference = create :any_reference, author_names: [author_name], citation_year: 1980
+          old_reference = create :any_reference, author_names: [author_name], year: 1980
           create(:any_taxon).protonym.authorship.update!(reference: old_reference)
         end
 

--- a/spec/decorators/journal_decorator_spec.rb
+++ b/spec/decorators/journal_decorator_spec.rb
@@ -7,14 +7,14 @@ describe JournalDecorator do
 
   describe "#publications_between" do
     let(:journal) { create :journal }
-    let!(:reference) { create :article_reference, citation_year: 2000, journal: journal }
+    let!(:reference) { create :article_reference, year: 2000, journal: journal }
 
     context "when start and end year are the same" do
       specify { expect(decorated.publications_between).to eq reference.year }
     end
 
     context "when start and end year are not the same" do
-      before { create :article_reference, citation_year: 2010, journal: journal }
+      before { create :article_reference, year: 2010, journal: journal }
 
       specify { expect(decorated.publications_between).to eq "2000–2010" }
     end

--- a/spec/exporters/exporters/antweb/taxon_attributes_spec.rb
+++ b/spec/exporters/exporters/antweb/taxon_attributes_spec.rb
@@ -24,7 +24,7 @@ describe Exporters::Antweb::TaxonAttributes do
       specify do
         reference = taxon.authorship_reference
         expect(described_class[taxon][:author_date_html]).
-          to eq %(<span title="#{reference.decorate.plain_text}">#{reference.key_with_citation_year}</span>)
+          to eq %(<span title="#{reference.decorate.plain_text}">#{reference.key_with_suffixed_year}</span>)
       end
     end
 

--- a/spec/exporters/exporters/endnote/formatter_spec.rb
+++ b/spec/exporters/exporters/endnote/formatter_spec.rb
@@ -8,7 +8,7 @@ describe Exporters::Endnote::Formatter do
       let(:reference) do
         create :article_reference,
           author_names: [create(:author_name, name: 'MacKay, W.')],
-          citation_year: '1941',
+          year: 1941,
           title: '*A title*',
           journal: create(:journal, name: 'Psyche'),
           series_volume_issue: '1(2)',
@@ -34,7 +34,7 @@ describe Exporters::Endnote::Formatter do
       let(:reference) do
         create :article_reference,
           author_names: [create(:author_name, name: 'MacKay, W.')],
-          citation_year: '1941',
+          year: 1941,
           title: '*A title*',
           journal: create(:journal, name: 'Psyche'),
           series_volume_issue: '1(2)',
@@ -65,7 +65,7 @@ describe Exporters::Endnote::Formatter do
         create :book_reference,
           author_names: [create(:author_name, name: 'Bolton, B.'), create(:author_name, name: 'Fisher, B.L.')],
           title: 'Ants Are My Life',
-          citation_year: '1933',
+          year: 1933,
           publisher: create(:publisher, name: 'Springer Verlag', place: 'Dresden'),
           pagination: 'ix + 33pp.'
       end
@@ -90,7 +90,7 @@ describe Exporters::Endnote::Formatter do
       let(:reference) do
         create :article_reference,
           author_names: [create(:author_name, name: 'MacKay, W.')],
-          citation_year: '1941',
+          year: 1941,
           title: 'A title',
           journal: create(:journal, name: 'Psyche'),
           series_volume_issue: '1(2)',

--- a/spec/factories/references.rb
+++ b/spec/factories/references.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     end
 
     sequence(:title) { |n| "Ants#{n}" }
-    sequence(:citation_year) { |n| "201#{n}d" }
+    sequence(:year) { |n| "201#{n}".to_i }
 
     after(:stub) do |reference, evaluator|
       if evaluator.author_names.present?

--- a/spec/factories/references.rb
+++ b/spec/factories/references.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# TODO: Generate proper years.
+
 FactoryBot.define do
   factory :base_reference, class: 'Reference' do
     transient do
@@ -50,6 +52,14 @@ FactoryBot.define do
     factory :nested_reference, class: 'NestedReference' do
       sequence(:pagination) { |n| "Pp. #{n} in:" }
       nesting_reference { create :book_reference }
+    end
+
+    trait :with_year_suffix do
+      sequence(:year_suffix, ('a'..'z').cycle)
+    end
+
+    trait :with_stated_year do
+      sequence(:stated_year) { |n| "200#{n}" }
     end
 
     trait :with_doi do

--- a/spec/factories/references.rb
+++ b/spec/factories/references.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# TODO: Generate proper years.
-
 FactoryBot.define do
   factory :base_reference, class: 'Reference' do
     transient do
@@ -9,7 +7,7 @@ FactoryBot.define do
     end
 
     sequence(:title) { |n| "Ants#{n}" }
-    sequence(:year) { |n| "201#{n}".to_i }
+    year { rand(Citation::ICZN_APPLICABILITY_YEAR_RANGE) }
 
     after(:stub) do |reference, evaluator|
       if evaluator.author_names.present?
@@ -59,7 +57,7 @@ FactoryBot.define do
     end
 
     trait :with_stated_year do
-      sequence(:stated_year) { |n| "200#{n}" }
+      stated_year { rand(Citation::ICZN_APPLICABILITY_YEAR_RANGE) }
     end
 
     trait :with_doi do

--- a/spec/forms/reference_form_spec.rb
+++ b/spec/forms/reference_form_spec.rb
@@ -306,7 +306,6 @@ describe ReferenceForm do
           author_names_string: original.author_names_string,
           journal_name: original.journal.name,
           year: original.year,
-          year_suffix: original.year_suffix,
           title: original.title,
           series_volume_issue: original.series_volume_issue,
           pagination: original.pagination

--- a/spec/forms/reference_form_spec.rb
+++ b/spec/forms/reference_form_spec.rb
@@ -221,7 +221,7 @@ describe ReferenceForm do
             ArticleReference.new(
               pagination: '12',
               title: 'Ants',
-              citation_year: '2000',
+              year: 2000,
               series_volume_issue: '123',
               journal: journal
             )
@@ -305,7 +305,8 @@ describe ReferenceForm do
         {
           author_names_string: original.author_names_string,
           journal_name: original.journal.name,
-          citation_year: original.citation_year,
+          year: original.year,
+          year_suffix: original.year_suffix,
           title: original.title,
           series_volume_issue: original.series_volume_issue,
           pagination: original.pagination

--- a/spec/injectable_formatters/antweb_formatter/reference_link_spec.rb
+++ b/spec/injectable_formatters/antweb_formatter/reference_link_spec.rb
@@ -8,7 +8,7 @@ describe AntwebFormatter::ReferenceLink do
     create :article_reference,
       :with_doi,
       author_names: [latreille],
-      citation_year: '1809',
+      year: 1809,
       title: "*Atta*",
       journal: create(:journal, name: 'Science'),
       series_volume_issue: '(1)',

--- a/spec/models/protonym_spec.rb
+++ b/spec/models/protonym_spec.rb
@@ -56,10 +56,10 @@ describe Protonym do
   end
 
   describe "#author_citation" do
-    let!(:reference) { create :any_reference, author_string: 'Bolton', citation_year: '2005b' }
+    let!(:reference) { create :any_reference, author_string: 'Bolton', year: 2005, year_suffix: 'b' }
     let!(:protonym) { create :protonym, authorship: create(:citation, reference: reference) }
 
-    it 'does not include letters from the `citation_year`' do
+    it 'does not include year suffixes' do
       expect(protonym.author_citation).to eq 'Bolton, 2005'
     end
   end

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -34,7 +34,7 @@ describe Reference do
         expect { duplicate.bolton_key = conflict.bolton_key }.
           to change { duplicate.valid? }.from(true).to(false)
         expect(duplicate.errors[:bolton_key].first).to include "Bolton key has already been taken by"
-        expect(duplicate.errors[:bolton_key].first).to include conflict.key_with_citation_year
+        expect(duplicate.errors[:bolton_key].first).to include conflict.key_with_suffixed_year
       end
     end
   end

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -73,7 +73,7 @@ describe Reference do
     end
 
     describe '#start_reviewing!' do
-      it "none transitions to start" do
+      it "transitions from 'none' to 'reviewing'" do
         expect { reference.start_reviewing! }.to change { reference.reviewing? }.to(true)
 
         expect(reference.can_start_reviewing?).to eq false
@@ -87,7 +87,7 @@ describe Reference do
         reference.start_reviewing!
       end
 
-      it "start transitions to finish" do
+      it "transitions from 'reviewing' to 'reviewed'" do
         expect { reference.finish_reviewing! }.to change { reference.reviewed? }.to(true)
 
         expect(reference.can_start_reviewing?).to eq false
@@ -102,7 +102,7 @@ describe Reference do
         reference.finish_reviewing!
       end
 
-      it "reviewed can transition back to reviewing" do
+      it "can transition 'reviewed' back to 'reviewing'" do
         expect { reference.restart_reviewing! }.to change { reference.reviewing? }.to(true)
 
         expect(reference.can_start_reviewing?).to eq false
@@ -127,7 +127,6 @@ describe Reference do
   end
 
   describe "#author_names_string" do
-    let(:ward) { create :author_name, name: 'Ward, P.S.' }
     let(:fisher) { create :author_name, name: 'Fisher, B.L.' }
 
     context "when reference has one author name" do
@@ -139,6 +138,7 @@ describe Reference do
     end
 
     context "when reference has more than one author name" do
+      let(:ward) { create :author_name, name: 'Ward, P.S.' }
       let(:reference) { create :any_reference, author_names: [fisher, ward] }
 
       it "separates multiple author names with semicolons" do
@@ -148,7 +148,7 @@ describe Reference do
   end
 
   describe "#author_names_string_with_suffix" do
-    context "when reference has a `author_names_suffix`" do
+    context "when reference has an `author_names_suffix`" do
       let(:reference) do
         fisher = create :author_name, name: 'Fisher, B.L.'
         create :any_reference, author_names: [fisher], author_names_suffix: '(ed.)'

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -22,9 +22,6 @@ describe Reference do
     it { is_expected.to validate_presence_of :title }
     it { is_expected.to_not allow_values('<', '>').for(:doi) }
 
-    it { is_expected.to allow_value('2000').for(:citation_year) }
-    it { is_expected.to allow_value('2000a').for(:citation_year) }
-    it { is_expected.to_not allow_value('2000A').for(:citation_year) }
     it { is_expected.to allow_value('a').for(:year_suffix) }
     it { is_expected.to_not allow_value('aa').for(:year_suffix) }
     it { is_expected.to_not allow_value('A').for(:year_suffix) }
@@ -44,18 +41,6 @@ describe Reference do
 
   describe 'callbacks' do
     it { is_expected.to strip_attributes(:public_notes, :editor_notes, :taxonomic_notes) }
-
-    describe "#set_year_from_citation_year" do
-      context 'when `citation_year` contains a letter' do
-        let(:reference) { create :any_reference, citation_year: '1910a' }
-
-        it "ignores letters when setting `year`" do
-          expect { reference.update!(citation_year: '2010b') }.
-            to change { reference.reload.year }.from(1910).to(2010)
-        end
-      end
-    end
-
     it { is_expected.to strip_attributes(:title, :date, :stated_year, :year_suffix, :bolton_key, :author_names_suffix) }
     it { is_expected.to strip_attributes(:series_volume_issue, :doi) }
   end
@@ -63,9 +48,9 @@ describe Reference do
   describe "scopes" do
     describe ".order_by_author_names_and_year" do
       it "sorts by author_name plus year plus letter" do
-        one = create :any_reference, author_string: 'Fisher', citation_year: '1910b'
-        two = create :any_reference, author_string: 'Wheeler', citation_year: '1874'
-        three = create :any_reference, author_string: 'Fisher', citation_year: '1910a'
+        one = create :any_reference, author_string: 'Fisher', year: 1910, year_suffix: "b"
+        two = create :any_reference, author_string: 'Wheeler', year: 1874
+        three = create :any_reference, author_string: 'Fisher', year: 1910, year_suffix: "a"
 
         expect(described_class.order_by_author_names_and_year).to eq [three, one, two]
       end
@@ -129,13 +114,13 @@ describe Reference do
 
   describe '#citation_year_with_stated_year' do
     context 'when reference does not have a `stated_year`' do
-      let(:reference) { create :any_reference, citation_year: "2000a" }
+      let(:reference) { create :any_reference, year: 2000, year_suffix: 'a' }
 
       specify { expect(reference.citation_year_with_stated_year).to eq '2000a' }
     end
 
     context 'when reference has a `stated_year`' do
-      let(:reference) { create :any_reference, citation_year: "2000a", stated_year: "2001" }
+      let(:reference) { create :any_reference, year: 2000, year_suffix: 'a', stated_year: "2001" }
 
       specify { expect(reference.citation_year_with_stated_year).to eq '2000a ("2001")' }
     end

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -112,17 +112,17 @@ describe Reference do
     end
   end
 
-  describe '#citation_year_with_stated_year' do
+  describe '#suffixed_year_with_stated_year' do
     context 'when reference does not have a `stated_year`' do
       let(:reference) { create :any_reference, year: 2000, year_suffix: 'a' }
 
-      specify { expect(reference.citation_year_with_stated_year).to eq '2000a' }
+      specify { expect(reference.suffixed_year_with_stated_year).to eq '2000a' }
     end
 
     context 'when reference has a `stated_year`' do
       let(:reference) { create :any_reference, year: 2000, year_suffix: 'a', stated_year: "2001" }
 
-      specify { expect(reference.citation_year_with_stated_year).to eq '2000a ("2001")' }
+      specify { expect(reference.suffixed_year_with_stated_year).to eq '2000a ("2001")' }
     end
   end
 

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -25,6 +25,9 @@ describe Reference do
     it { is_expected.to allow_value('2000').for(:citation_year) }
     it { is_expected.to allow_value('2000a').for(:citation_year) }
     it { is_expected.to_not allow_value('2000A').for(:citation_year) }
+    it { is_expected.to allow_value('a').for(:year_suffix) }
+    it { is_expected.to_not allow_value('aa').for(:year_suffix) }
+    it { is_expected.to_not allow_value('A').for(:year_suffix) }
 
     describe '`bolton_key` uniqueness' do
       let!(:conflict) { create :any_reference, bolton_key: 'Batiatus 2000' }
@@ -41,7 +44,6 @@ describe Reference do
 
   describe 'callbacks' do
     it { is_expected.to strip_attributes(:public_notes, :editor_notes, :taxonomic_notes) }
-    it { is_expected.to strip_attributes(:title, :date, :stated_year, :series_volume_issue, :doi, :bolton_key, :author_names_suffix) }
 
     describe "#set_year_from_citation_year" do
       context 'when `citation_year` contains a letter' do
@@ -53,6 +55,9 @@ describe Reference do
         end
       end
     end
+
+    it { is_expected.to strip_attributes(:title, :date, :stated_year, :year_suffix, :bolton_key, :author_names_suffix) }
+    it { is_expected.to strip_attributes(:series_volume_issue, :doi) }
   end
 
   describe "scopes" do

--- a/spec/models/references/key_spec.rb
+++ b/spec/models/references/key_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe References::Key do
   subject(:key) { described_class.new(reference) }
 
-  describe "#key_with_citation_year" do
+  describe "#key_with_suffixed_year" do
     let(:bolton) { create :author_name, name: 'Bolton, B.' }
     let(:fisher) { create :author_name, name: 'Fisher, B.' }
 
@@ -13,20 +13,20 @@ describe References::Key do
       let(:reference) { create :any_reference, :with_author_name, year: 1970, year_suffix: 'a' }
 
       specify do
-        expect { reference.author_names = [] }.to change { key.key_with_citation_year }.to('[no authors], 1970a')
+        expect { reference.author_names = [] }.to change { key.key_with_suffixed_year }.to('[no authors], 1970a')
       end
     end
 
     context 'when one author' do
       let(:reference) { create :any_reference, author_names: [bolton], year: 1970, year_suffix: 'a' }
 
-      specify { expect(key.key_with_citation_year).to eq 'Bolton, 1970a' }
+      specify { expect(key.key_with_suffixed_year).to eq 'Bolton, 1970a' }
     end
 
     context 'when two authors' do
       let(:reference) { create :any_reference, author_names: [bolton, fisher], year: 1970, year_suffix: 'a' }
 
-      specify { expect(key.key_with_citation_year).to eq 'Bolton & Fisher, 1970a' }
+      specify { expect(key.key_with_suffixed_year).to eq 'Bolton & Fisher, 1970a' }
     end
 
     context 'when three authors' do
@@ -35,8 +35,8 @@ describe References::Key do
         create :any_reference, author_names: [bolton, fisher, ward], year: 1970, year_suffix: 'a'
       end
 
-      specify { expect(key.key_with_citation_year).to eq 'Bolton <i>et al.</i>, 1970a' }
-      specify { expect(key.key_with_citation_year.html_safe?).to eq true }
+      specify { expect(key.key_with_suffixed_year).to eq 'Bolton <i>et al.</i>, 1970a' }
+      specify { expect(key.key_with_suffixed_year.html_safe?).to eq true }
     end
   end
 

--- a/spec/models/references/key_spec.rb
+++ b/spec/models/references/key_spec.rb
@@ -10,7 +10,7 @@ describe References::Key do
     let(:fisher) { create :author_name, name: 'Fisher, B.' }
 
     context 'when no authors' do
-      let(:reference) { create :any_reference, :with_author_name, citation_year: '1970a' }
+      let(:reference) { create :any_reference, :with_author_name, year: 1970, year_suffix: 'a' }
 
       specify do
         expect { reference.author_names = [] }.to change { key.key_with_citation_year }.to('[no authors], 1970a')
@@ -18,13 +18,13 @@ describe References::Key do
     end
 
     context 'when one author' do
-      let(:reference) { create :any_reference, author_names: [bolton], citation_year: '1970a' }
+      let(:reference) { create :any_reference, author_names: [bolton], year: 1970, year_suffix: 'a' }
 
       specify { expect(key.key_with_citation_year).to eq 'Bolton, 1970a' }
     end
 
     context 'when two authors' do
-      let(:reference) { create :any_reference, author_names: [bolton, fisher], citation_year: '1970a' }
+      let(:reference) { create :any_reference, author_names: [bolton, fisher], year: 1970, year_suffix: 'a' }
 
       specify { expect(key.key_with_citation_year).to eq 'Bolton & Fisher, 1970a' }
     end
@@ -32,7 +32,7 @@ describe References::Key do
     context 'when three authors' do
       let(:reference) do
         ward = create :author_name, name: 'Ward, P.S.'
-        create :any_reference, author_names: [bolton, fisher, ward], citation_year: '1970a'
+        create :any_reference, author_names: [bolton, fisher, ward], year: 1970, year_suffix: 'a'
       end
 
       specify { expect(key.key_with_citation_year).to eq 'Bolton <i>et al.</i>, 1970a' }
@@ -41,7 +41,7 @@ describe References::Key do
   end
 
   describe "#key_with_year" do
-    let(:reference) { create :any_reference, author_string: 'Bolton', citation_year: '1885g' }
+    let(:reference) { create :any_reference, author_string: 'Bolton', year: 1885, year_suffix: 'g' }
 
     it "doesn't include the year ordinal" do
       expect(key.key_with_year).to eq 'Bolton, 1885'

--- a/spec/models/taxon_spec.rb
+++ b/spec/models/taxon_spec.rb
@@ -157,7 +157,7 @@ describe Taxon do
   end
 
   describe "#author_citation" do
-    let!(:reference) { create :any_reference, author_string: 'Bolton', citation_year: '2005' }
+    let!(:reference) { create :any_reference, author_string: 'Bolton', year: 2005 }
 
     before do
       taxon.protonym.update!(name: protonym_name)

--- a/spec/queries/catalog/advanced_search_query_spec.rb
+++ b/spec/queries/catalog/advanced_search_query_spec.rb
@@ -43,7 +43,7 @@ describe Catalog::AdvancedSearchQuery do
       let!(:taxon) { create :subfamily }
 
       before do
-        reference = create :any_reference, citation_year: '1977'
+        reference = create :any_reference, year: 1977
         taxon.protonym.authorship.update!(reference: reference)
       end
 

--- a/spec/queries/references/fulltext_search_light_query_spec.rb
+++ b/spec/queries/references/fulltext_search_light_query_spec.rb
@@ -19,7 +19,7 @@ describe References::FulltextSearchLightQuery, :search do
           bolton = create :author_name, name: 'Bolton, B.'
           fisher = create :author_name, name: 'Fisher, B.'
 
-          create :any_reference, author_names: [bolton, fisher], citation_year: '1970a'
+          create :any_reference, author_names: [bolton, fisher], year: 1970, year_suffix: "a"
         end
 
         before { Sunspot.commit }
@@ -33,7 +33,7 @@ describe References::FulltextSearchLightQuery, :search do
           fisher = create :author_name, name: 'Fisher, B.'
           ward = create :author_name, name: 'Ward, P.S.'
 
-          create :any_reference, author_names: [bolton, fisher, ward], citation_year: '1970a'
+          create :any_reference, author_names: [bolton, fisher, ward], year: 1970, year_suffix: "a"
         end
 
         before { Sunspot.commit }
@@ -45,21 +45,21 @@ describe References::FulltextSearchLightQuery, :search do
     describe "ordering" do
       let(:service) { described_class.new("Forel 1911") }
 
-      context "when references have the same year but different citation years" do
-        let!(:forel_a) { create :any_reference, author_string: "Forel", citation_year: "1911a" }
-        let!(:forel_b) { create :any_reference, author_string: "Forel", citation_year: "1911b" }
+      context "when references have the same `year` but different `year_suffix`" do
+        let!(:forel_a) { create :any_reference, author_string: "Forel", year: 1911, year_suffix: "a" }
+        let!(:forel_b) { create :any_reference, author_string: "Forel", year: 1911, year_suffix: "b" }
 
-        it "orders by citation year" do
+        it "orders by suffixed year" do
           Sunspot.commit
           expect(service.call).to eq [forel_a, forel_b]
         end
 
         context "when there is also a less relevant hit" do
           let!(:less_relevant) do
-            create :any_reference, author_string: "Other", citation_year: "1912", title: "Forel 1911 was here"
+            create :any_reference, author_string: "Other", year: 1912, title: "Forel 1911 was here"
           end
 
-          it "orders by citation year and places less relevant hits last" do
+          it "orders by suffixed year and places less relevant hits last" do
             Sunspot.commit
             expect(service.call).to eq [forel_a, forel_b, less_relevant]
           end

--- a/spec/queries/references/fulltext_search_light_query_spec.rb
+++ b/spec/queries/references/fulltext_search_light_query_spec.rb
@@ -19,12 +19,12 @@ describe References::FulltextSearchLightQuery, :search do
           bolton = create :author_name, name: 'Bolton, B.'
           fisher = create :author_name, name: 'Fisher, B.'
 
-          create :any_reference, author_names: [bolton, fisher], year: 1970, year_suffix: "a"
+          create :any_reference, author_names: [bolton, fisher], year: 1970
         end
 
         before { Sunspot.commit }
 
-        specify { expect(described_class["Fisher & Bolton 1970a"]).to eq [reference] }
+        specify { expect(described_class["Fisher & Bolton 1970"]).to eq [reference] }
       end
 
       context "when search query contains 'et al.'" do
@@ -33,12 +33,12 @@ describe References::FulltextSearchLightQuery, :search do
           fisher = create :author_name, name: 'Fisher, B.'
           ward = create :author_name, name: 'Ward, P.S.'
 
-          create :any_reference, author_names: [bolton, fisher, ward], year: 1970, year_suffix: "a"
+          create :any_reference, author_names: [bolton, fisher, ward], year: 1970
         end
 
         before { Sunspot.commit }
 
-        specify { expect(described_class["Fisher, et al. 1970a"]).to eq [reference] }
+        specify { expect(described_class["Fisher, et al. 1970"]).to eq [reference] }
       end
     end
 
@@ -56,7 +56,7 @@ describe References::FulltextSearchLightQuery, :search do
 
         context "when there is also a less relevant hit" do
           let!(:less_relevant) do
-            create :any_reference, author_string: "Other", year: 1912, title: "Forel 1911 was here"
+            create :any_reference, author_string: "Other", year: 1912, title: "Forel 1911 title hit"
           end
 
           it "orders by suffixed year and places less relevant hits last" do

--- a/spec/queries/references/fulltext_search_query_spec.rb
+++ b/spec/queries/references/fulltext_search_query_spec.rb
@@ -38,7 +38,7 @@ describe References::FulltextSearchQuery, :search do
         before do
           create :any_reference, year: 1994
           create :any_reference, year: 1995
-          create :any_reference, year: 1996, year_suffix: 'a'
+          create :any_reference, year: 1996
           create :any_reference, year: 1998
           Sunspot.commit
         end
@@ -268,12 +268,12 @@ describe References::FulltextSearchQuery, :search do
         bolton = create :author_name, name: 'Bolton, B.'
         fisher = create :author_name, name: 'Fisher, B.'
 
-        create :any_reference, author_names: [bolton, fisher], year: 1970, year_suffix: 'a'
+        create :any_reference, author_names: [bolton, fisher], year: 1970
       end
 
       before { Sunspot.commit }
 
-      specify { expect(described_class[freetext: "Fisher & Bolton 1970a"]).to eq [reference] }
+      specify { expect(described_class[freetext: "Fisher & Bolton 1970"]).to eq [reference] }
     end
 
     context "when search query contains 'et al.'" do
@@ -282,12 +282,12 @@ describe References::FulltextSearchQuery, :search do
         fisher = create :author_name, name: 'Fisher, B.'
         ward = create :author_name, name: 'Ward, P.S.'
 
-        create :any_reference, author_names: [bolton, fisher, ward], year: 1970, year_suffix: 'a'
+        create :any_reference, author_names: [bolton, fisher, ward], year: 1970
       end
 
       before { Sunspot.commit }
 
-      specify { expect(described_class[freetext: "Fisher, et al. 1970a"]).to eq [reference] }
+      specify { expect(described_class[freetext: "Fisher, et al. 1970"]).to eq [reference] }
     end
 
     describe "replacing some characters to make search work" do

--- a/spec/queries/references/fulltext_search_query_spec.rb
+++ b/spec/queries/references/fulltext_search_query_spec.rb
@@ -36,10 +36,10 @@ describe References::FulltextSearchQuery, :search do
 
       describe 'keywords: `start_year`, `end_year` and `year`' do
         before do
-          create :any_reference, citation_year: '1994'
-          create :any_reference, citation_year: '1995'
-          create :any_reference, citation_year: '1996a'
-          create :any_reference, citation_year: '1998'
+          create :any_reference, year: 1994
+          create :any_reference, year: 1995
+          create :any_reference, year: 1996, year_suffix: 'a'
+          create :any_reference, year: 1998
           Sunspot.commit
         end
 
@@ -50,11 +50,11 @@ describe References::FulltextSearchQuery, :search do
       end
 
       describe "keyword: `year`" do
-        let!(:reference_2004) { create :any_reference, citation_year: '2004' }
-        let!(:reference_2005b) { create :any_reference, citation_year: '2005b' }
+        let!(:reference_2004) { create :any_reference, year: 2004 }
+        let!(:reference_2005b) { create :any_reference, year: 2005, year_suffix: 'b' }
 
         before do
-          create :any_reference, citation_year: '2003'
+          create :any_reference, year: 2003
           Sunspot.commit
         end
 
@@ -268,7 +268,7 @@ describe References::FulltextSearchQuery, :search do
         bolton = create :author_name, name: 'Bolton, B.'
         fisher = create :author_name, name: 'Fisher, B.'
 
-        create :any_reference, author_names: [bolton, fisher], citation_year: '1970a'
+        create :any_reference, author_names: [bolton, fisher], year: 1970, year_suffix: 'a'
       end
 
       before { Sunspot.commit }
@@ -282,7 +282,7 @@ describe References::FulltextSearchQuery, :search do
         fisher = create :author_name, name: 'Fisher, B.'
         ward = create :author_name, name: 'Ward, P.S.'
 
-        create :any_reference, author_names: [bolton, fisher, ward], citation_year: '1970a'
+        create :any_reference, author_names: [bolton, fisher, ward], year: 1970, year_suffix: 'a'
       end
 
       before { Sunspot.commit }

--- a/spec/serializers/api/v1/reference_serializer_spec.rb
+++ b/spec/serializers/api/v1/reference_serializer_spec.rb
@@ -13,7 +13,7 @@ describe Api::V1::ReferenceSerializer do
             "id" => reference.id,
             "title" => reference.title,
             "year" => reference.year,
-            "citation_year" => reference.citation_year,
+            "year_suffix" => reference.year_suffix,
             "stated_year" => reference.stated_year,
             "date" => nil,
             "doi" => nil,

--- a/spec/serializers/autocomplete/linkable_references_serializer_spec.rb
+++ b/spec/serializers/autocomplete/linkable_references_serializer_spec.rb
@@ -13,7 +13,7 @@ describe Autocomplete::LinkableReferencesSerializer do
             {
               id: reference.id,
               author: reference.author_names_string_with_suffix,
-              year: reference.citation_year,
+              year: reference.suffixed_year,
               title: "#{reference.title}.",
               full_pagination: "[pagination: #{reference.pagination} (#{reference.nesting_reference.pagination})]",
               bolton_key: "[Bolton key: #{reference.bolton_key}]"

--- a/spec/serializers/autocomplete/references_serializer_spec.rb
+++ b/spec/serializers/autocomplete/references_serializer_spec.rb
@@ -18,7 +18,7 @@ describe Autocomplete::ReferencesSerializer do
             author: "E.O. Wilson",
             search_query: reference.title,
             title: reference.title,
-            year: reference.citation_year,
+            year: reference.suffixed_year,
             url: "/references/#{reference.id}"
           }
         ]
@@ -34,7 +34,7 @@ describe Autocomplete::ReferencesSerializer do
               author: "E.O. Wilson",
               search_query: "author:'E.O. Wilson'",
               title: reference.title,
-              year: reference.citation_year,
+              year: reference.suffixed_year,
               url: "/references/#{reference.id}"
             }
           ]

--- a/spec/serializers/autocomplete/references_serializer_spec.rb
+++ b/spec/serializers/autocomplete/references_serializer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe Autocomplete::ReferencesSerializer do
   describe "#call" do
-    let!(:reference) { create :any_reference, author_string: 'E.O. Wilson' }
+    let!(:reference) { create :any_reference, :with_year_suffix, :with_stated_year, author_string: 'E.O. Wilson' }
 
     before do
       Sunspot.commit
@@ -18,7 +18,7 @@ describe Autocomplete::ReferencesSerializer do
             author: "E.O. Wilson",
             search_query: reference.title,
             title: reference.title,
-            year: reference.suffixed_year,
+            year: reference.suffixed_year_with_stated_year,
             url: "/references/#{reference.id}"
           }
         ]
@@ -34,7 +34,7 @@ describe Autocomplete::ReferencesSerializer do
               author: "E.O. Wilson",
               search_query: "author:'E.O. Wilson'",
               title: reference.title,
-              year: reference.suffixed_year,
+              year: reference.suffixed_year_with_stated_year,
               url: "/references/#{reference.id}"
             }
           ]

--- a/spec/services/references/formatted/expandable_spec.rb
+++ b/spec/services/references/formatted/expandable_spec.rb
@@ -8,7 +8,7 @@ describe References::Formatted::Expandable do
   describe '#call' do
     let(:author_name) { create :author_name, name: "Forel, A." }
     let(:reference) do
-      create :article_reference, :with_doi, author_names: [author_name], citation_year: '1874',
+      create :article_reference, :with_doi, author_names: [author_name], year: 1874,
         title: "*Italics* <i>and such</i>", series_volume_issue: '(1)', pagination: '3'
     end
 

--- a/spec/services/references/formatted/expanded_spec.rb
+++ b/spec/services/references/formatted/expanded_spec.rb
@@ -11,7 +11,7 @@ describe References::Formatted::Expanded do
     context 'when reference is an `ArticleReference`' do
       let(:author_name) { create :author_name, name: "Forel, A." }
       let(:reference) do
-        create :article_reference, :with_doi, author_names: [author_name], citation_year: '1874',
+        create :article_reference, :with_doi, author_names: [author_name], year: 1874,
           title: "*Italics* <i>and such</i>", series_volume_issue: '(1)', pagination: '3'
       end
 
@@ -29,7 +29,7 @@ describe References::Formatted::Expanded do
       let(:author_name) { create :author_name, name: "Forel, A." }
       let(:reference) do
         create :book_reference, author_names: [author_name],
-          citation_year: "1874", title: '*Ants* <i>and such</i>', pagination: "22 pp.",
+          year: 1874, title: '*Ants* <i>and such</i>', pagination: "22 pp.",
           publisher: create(:publisher, name: 'Wiley', place: 'San Francisco')
       end
 
@@ -48,13 +48,13 @@ describe References::Formatted::Expanded do
       let(:author_name) { create :author_name, name: "Forel, A." }
       let(:nestee_reference) do
         create :book_reference, author_names: [nestee_author_name],
-          citation_year: '2010', title: '*Lasius* <i>and such</i>', pagination: '32 pp.',
+          year: 2010, title: '*Lasius* <i>and such</i>', pagination: '32 pp.',
           publisher: create(:publisher, name: 'Wiley', place: 'New York')
       end
       let(:reference) do
         create :nested_reference, nesting_reference: nestee_reference,
           author_names: [author_name], title: '*Italics* <i>and such</i>',
-          citation_year: '1874', pagination: 'Pp. 32-45 in:'
+          year: 1874, pagination: 'Pp. 32-45 in:'
       end
 
       specify { expect(formatter.call.html_safe?).to eq true }

--- a/spec/services/references/formatted/plain_text_spec.rb
+++ b/spec/services/references/formatted/plain_text_spec.rb
@@ -9,7 +9,7 @@ describe References::Formatted::PlainText do
     context 'when reference is an `ArticleReference`' do
       let(:author_name) { create :author_name, name: "Forel, A." }
       let(:reference) do
-        create :article_reference, :with_doi, author_names: [author_name], citation_year: '1874',
+        create :article_reference, :with_doi, author_names: [author_name], year: 1874,
           title: "*Italics* <i>and such</i>", series_volume_issue: '(1)', pagination: '3'
       end
 
@@ -39,7 +39,7 @@ describe References::Formatted::PlainText do
       let(:author_name) { create :author_name, name: "Forel, A." }
       let(:reference) do
         create :book_reference, author_names: [author_name],
-          citation_year: "1874", title: '*Ants* <i>and such</i>', pagination: "22 pp.",
+          year: 1874, title: '*Ants* <i>and such</i>', pagination: "22 pp.",
           publisher: create(:publisher, name: 'Wiley', place: 'San Francisco')
       end
 
@@ -67,13 +67,13 @@ describe References::Formatted::PlainText do
     context 'when reference is a `NestedReference`' do
       let(:nestee_reference) do
         create :book_reference, author_names: [create(:author_name, name: "Mayr, E.")],
-          citation_year: '2010', title: '*Lasius* <i>and such</i>', pagination: '32 pp.',
+          year: 2010, title: '*Lasius* <i>and such</i>', pagination: '32 pp.',
           publisher: create(:publisher, name: 'Wiley', place: 'New York')
       end
       let(:reference) do
         create :nested_reference, nesting_reference: nestee_reference,
           author_names: [create(:author_name, name: "Forel, A.")], title: '*Italics* <i>and such</i>',
-          citation_year: '1874', pagination: 'Pp. 32-45 in:'
+          year: 1874, pagination: 'Pp. 32-45 in:'
       end
 
       specify { expect(formatter.call.html_safe?).to eq true }

--- a/spec/services/references/new_from_copy_spec.rb
+++ b/spec/services/references/new_from_copy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe References::NewFromCopy do
   describe '#call' do
     describe 'copying common attributes' do
-      let!(:reference) { create :article_reference, :with_notes, year_suffix: 'a', stated_year: "2001" }
+      let!(:reference) { create :article_reference, :with_year_suffix, :with_stated_year, :with_notes }
 
       specify do
         copy = described_class[reference]

--- a/spec/services/references/new_from_copy_spec.rb
+++ b/spec/services/references/new_from_copy_spec.rb
@@ -5,14 +5,15 @@ require 'rails_helper'
 describe References::NewFromCopy do
   describe '#call' do
     describe 'copying common attributes' do
-      let!(:reference) { create :article_reference, :with_notes, stated_year: "2001" }
+      let!(:reference) { create :article_reference, :with_notes, year_suffix: 'a', stated_year: "2001" }
 
       specify do
         copy = described_class[reference]
 
         [
           :author_names_string_cache,
-          :citation_year,
+          :year,
+          :year_suffix,
           :stated_year,
           :title,
           :pagination,

--- a/spec/services/wikipedia/reference_exporter_spec.rb
+++ b/spec/services/wikipedia/reference_exporter_spec.rb
@@ -10,7 +10,7 @@ describe Wikipedia::ReferenceExporter do
     describe "when reference is an `ArticleReference`" do
       let(:reference) do
         create :article_reference, :with_doi, author_names: [batiatus], title: "*Formica* and Apples",
-          pagination: "7-14", citation_year: "2000"
+          pagination: "7-14", year: 2000
       end
 
       specify do
@@ -26,7 +26,7 @@ describe Wikipedia::ReferenceExporter do
     describe "when reference is a `BookReference`" do
       let(:reference) do
         create :book_reference, author_names: [batiatus, glaber], title: "*Formica* and Apples",
-          pagination: "7-14", citation_year: "2000", publisher: create(:publisher, name: 'Wiley', place: 'San Francisco')
+          pagination: "7-14", year: 2000, publisher: create(:publisher, name: 'Wiley', place: 'San Francisco')
       end
 
       specify do
@@ -41,7 +41,7 @@ describe Wikipedia::ReferenceExporter do
     end
 
     describe "name tag" do
-      let(:reference) { create :article_reference, author_names: author_names, citation_year: "2016" }
+      let(:reference) { create :article_reference, author_names: author_names, year: 2016 }
 
       context "when reference has one author" do
         let(:author_names) { [batiatus] }


### PR DESCRIPTION
More normalized data and fewer callbacks.