### PR TITLE
Add bundle install command to dockerfile

### DIFF
--- a/docker/antcat-database.docker
+++ b/docker/antcat-database.docker
@@ -1,15 +1,35 @@
 FROM ruby:2.7.1
 
 # TODO: qt-related dependencies can be removed after switching from capybara-webkit to apparition.
-RUN apt-get update -qq && apt-get install -y nodejs default-mysql-client qt5-default libqt5webkit5-dev qtchooser openssh-server; gem install bundler -v '2.1.1';  mkdir /var/run/sshd ; echo 'root:root' | chpasswd ; sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config ; echo "export VISIBLE=now" >> /etc/profile
+RUN apt-get update -qq && apt-get install -y \
+default-mysql-client \
+libqt5webkit5-dev \
+nodejs \
+openssh-server \
+qt5-default \
+qtchooser
+
+RUN gem install bundler -v '2.1.1'
+
+RUN mkdir /var/run/sshd \
+&& echo 'root:root' | chpasswd \
+&& sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
+&& echo "export VISIBLE=now" >> /etc/profile
 # SSH login fix. Otherwise user is kicked off after login
 #RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
-ENV NOTVISIBLE "in users profile"
+ENV NOTVISIBLE="in users profile" \
+    PATH="/code/bin:${PATH}"
 #RUN echo "export VISIBLE=now" >> /etc/profile
-ENV PATH="/code/bin:${PATH}"
 #EXPOSE 22
 #CMD ["/usr/sbin/sshd", "-D", "-e", "-f", "/etc/ssh/sshd_config"]
+
+# Run bundle install first so it can be cached between builds and not invalidated when code changes
+COPY Gemfile* /tmp/
+WORKDIR /tmp
+RUN bundle install
+
+RUN mkdir /code
 ADD . /code/
 WORKDIR /code
 


### PR DESCRIPTION
Docker can cache the result of `bundle install` for subsequent builds. By adding it to the docker image, the gems don't need to be downloaded and installed for every run.

Splitting up the run commands allows less of the build cache to be invalidated when the codebase changes.