### PR TITLE
Fix to make hidden `abbr` underlines visible

### DIFF
--- a/app/assets/stylesheets/foundation_and_overrides.sass
+++ b/app/assets/stylesheets/foundation_and_overrides.sass
@@ -264,10 +264,6 @@ table th
   @extend .label
   border-radius: 10px
 
-// To prevent the underline from appearing twice.
-abbr[title]
-  border-bottom: 0
-
 table
   border-spacing: 0
 


### PR DESCRIPTION
Fix for issue introduced in https://github.com/calacademy-research/antcat/pull/1265