### PR TITLE
Unify database script taggings (`tags` vs. `section` vs. `category`)

### DIFF
--- a/app/decorators/database_script_decorator.rb
+++ b/app/decorators/database_script_decorator.rb
@@ -26,8 +26,7 @@ class DatabaseScriptDecorator < Draper::Decorator
   end
 
   def format_tags
-    tags_and_sections = ([section] + tags).compact - [DatabaseScripts::Tagging::MAIN_SECTION]
-    self.class.format_tags(tags_and_sections)
+    self.class.format_tags(tags)
   end
 
   def soft_validated?

--- a/app/models/database_script.rb
+++ b/app/models/database_script.rb
@@ -11,7 +11,7 @@ class DatabaseScript
 
   attr_accessor :results_runtime
 
-  delegate :title, :section, :category, :tags, :issue_description, :description, :related_scripts, to: :end_data_attributes
+  delegate :title, :section, :tags, :issue_description, :description, :related_scripts, to: :end_data_attributes
 
   class << self
     def new_from_basename basename

--- a/app/models/database_scripts/end_data_attributes.rb
+++ b/app/models/database_scripts/end_data_attributes.rb
@@ -14,10 +14,6 @@ module DatabaseScripts
       end_data[:section] || DatabaseScripts::Tagging::UNGROUPED_SECTION
     end
 
-    def category
-      end_data[:category] || ""
-    end
-
     def tags
       end_data[:tags] || []
     end

--- a/app/views/database_scripts/index.haml
+++ b/app/views/database_scripts/index.haml
@@ -68,7 +68,6 @@
       %table.tablesorter.huge-margin-bottom
         %thead
           %tr
-            %th.no-wrap Category
             %th Script
             %th.no-wrap Tags
             %th Soft-validated
@@ -79,7 +78,6 @@
           -database_scripts.each do |database_script|
             -decorated = database_script.decorate
             %tr
-              %td.shrink=database_script.category
               %td
                 =link_to database_script.title, database_script_path(database_script)
                 -if database_script.issue_description.present?

--- a/app/views/database_scripts/show.haml
+++ b/app/views/database_scripts/show.haml
@@ -10,9 +10,6 @@
 .row.collapse.margin-bottom
   .medium-8.columns
     %h5
-      -if @database_script.category.present?
-        =succeed ":" do
-          =@database_script.category
       =@database_script.title
       =@decorated_database_script.format_tags
     %p=markdown @database_script.description

--- a/features/editors_panel/database_scripts.feature
+++ b/features/editors_panel/database_scripts.feature
@@ -18,7 +18,7 @@ Feature: Database scripts
     Then I should see "The parent of this taxon is fossil, but this taxon is extant"
 
     When I follow the first "See more similiar."
-    Then I should see "Catalog: Extant taxa in fossil genera"
+    Then I should see "Extant taxa in fossil genera"
 
   Scenario: Clicking on all scripts just to see if the page renders
     Given I open all database scripts one by one

--- a/lib/generators/templates/database_script.rb.erb
+++ b/lib/generators/templates/database_script.rb.erb
@@ -26,7 +26,6 @@ __END__
 # title: <%= class_name.underscore.humanize(keep_id_suffix: true) %>
 
 section: main|regression-test|list
-category: Catalog, References... see the script index page
 tags: [new!, example-tag]
 
 issue_description: Optional short description; parsed as **markdown**.

--- a/spec/decorators/database_script_decorator_spec.rb
+++ b/spec/decorators/database_script_decorator_spec.rb
@@ -13,23 +13,9 @@ describe DatabaseScriptDecorator do
 
   describe "#format_tags" do
     context 'when testing with a real script' do
-      let(:database_script) { DatabaseScripts::TaxaWithSameName.new }
+      let(:database_script) { DatabaseScripts::OrphanedProtonyms.new }
 
-      specify { expect(decorated.format_tags).to eq '<span class="white-label rounded-badge">list</span>' }
-    end
-
-    context "when script is in the 'main' section" do
-      let(:database_script) { DatabaseScripts::TaxaWithSameName.new }
-
-      before do
-        def database_script.section
-          DatabaseScripts::Tagging::MAIN_SECTION
-        end
-      end
-
-      it "does not include 'main' in the tags" do
-        expect(decorated.format_tags).to eq ""
-      end
+      specify { expect(decorated.format_tags).to eq '<span class="warning-label rounded-badge">slow-render</span>' }
     end
 
     context 'when script is an `UnfoundDatabaseScript`' do

--- a/spec/models/database_scripts/end_data_attributes_spec.rb
+++ b/spec/models/database_scripts/end_data_attributes_spec.rb
@@ -18,10 +18,6 @@ describe DatabaseScripts::EndDataAttributes do
       specify { expect(end_data_attributes.section).to eq "regression-test" }
     end
 
-    describe "#category" do
-      specify { expect(end_data_attributes.category).to eq "Catalog" }
-    end
-
     describe "#tags" do
       specify { expect(end_data_attributes.tags).to eq [] }
     end
@@ -55,7 +51,6 @@ describe DatabaseScripts::EndDataAttributes do
       {
         title: "Pizza Championship",
         section: "Quality pizzas",
-        category: "Classic pizzas",
         tags: ['pescatore, funghi'],
         issue_description: "pizza was cold",
         description: "with tuna",
@@ -71,7 +66,6 @@ describe DatabaseScripts::EndDataAttributes do
 
     specify { expect(end_data_attributes.title).to eq end_data[:title] }
     specify { expect(end_data_attributes.section).to eq end_data[:section] }
-    specify { expect(end_data_attributes.category).to eq end_data[:category] }
     specify { expect(end_data_attributes.tags).to eq end_data[:tags] }
     specify { expect(end_data_attributes.issue_description).to eq end_data[:issue_description] }
     specify { expect(end_data_attributes.description).to eq end_data[:description] }
@@ -105,7 +99,6 @@ describe DatabaseScripts::EndDataAttributes do
     describe "defaults" do
       specify { expect(end_data_attributes.title).to eq "" }
       specify { expect(end_data_attributes.section).to eq 'ungrouped' }
-      specify { expect(end_data_attributes.category).to eq '' }
       specify { expect(end_data_attributes.tags).to eq [] }
       specify { expect(end_data_attributes.issue_description).to eq nil }
       specify { expect(end_data_attributes.description).to eq '' }

--- a/spec/services/markdowns/parse_antcat_tags_spec.rb
+++ b/spec/services/markdowns/parse_antcat_tags_spec.rb
@@ -30,9 +30,9 @@ describe Markdowns::ParseAntcatTags do
     describe 'tag: `DBSCRIPT_TAG_REGEX`' do
       context 'when database script exists' do
         specify do
-          expect(described_class["%dbscript:TaxaWithSameName"].strip).to eq <<~HTML.squish
-            <a href="/database_scripts/taxa_with_same_name">Taxa with same name</a>
-            <span class="white-label rounded-badge">list</span>
+          expect(described_class["%dbscript:OrphanedProtonyms"].strip).to eq <<~HTML.squish
+            <a href="/database_scripts/orphaned_protonyms">Orphaned protonyms</a>
+            <span class="warning-label rounded-badge">slow-render</span>
           HTML
         end
       end


### PR DESCRIPTION
For https://github.com/calacademy-research/antcat-issues/issues/113