### PR TITLE
Don't allow creating new `ReferenceDocument`s with `url`s

### DIFF
--- a/app/controllers/api/v1/reference_documents_controller.rb
+++ b/app/controllers/api/v1/reference_documents_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class ReferenceDocumentsController < Api::ApiController
-      ATTRIBUTES = [:id, :reference_id, :file_file_name, :url, :public, :created_at, :updated_at]
+      ATTRIBUTES = [:id, :reference_id, :file_file_name, :url, :created_at, :updated_at]
 
       def index
         render json: with_limit(ReferenceDocument.all).as_json(only: ATTRIBUTES, root: true)

--- a/app/controllers/references/downloads_controller.rb
+++ b/app/controllers/references/downloads_controller.rb
@@ -4,12 +4,7 @@ module References
   class DownloadsController < ApplicationController
     def show
       reference_document = find_reference_document
-
-      if reference_document.downloadable?
-        redirect_to reference_document.actual_url
-      else
-        head :unauthorized
-      end
+      redirect_to reference_document.actual_url
     end
 
     private

--- a/app/exporters/exporters/endnote/formatter.rb
+++ b/app/exporters/exporters/endnote/formatter.rb
@@ -49,7 +49,7 @@ module Exporters
         attr_reader :reference
         attr_accessor :string
 
-        delegate :author_names, :year, :title, :public_notes, :taxonomic_notes, :routed_url, to: :reference
+        delegate :author_names, :year, :title, :public_notes, :taxonomic_notes, to: :reference
 
         def add tag, value
           string << "%#{tag} #{value.to_s.gsub(/[|*]/, '')}" if value.present?
@@ -59,6 +59,11 @@ module Exporters
           author_names.each do |author|
             add "A", author.name
           end
+        end
+
+        def routed_url
+          return unless reference.downloadable?
+          reference.routed_url
         end
     end
 

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -17,7 +17,7 @@ class Reference < ApplicationRecord
   IGNORE_PAPER_TRAIL_COLUMNS = CACHE_COLUMNS
   SOLR_IGNORE_ATTRIBUTE_CHANGES_OF = CACHE_COLUMNS
 
-  delegate :routed_url, to: :document, allow_nil: true
+  delegate :routed_url, to: :document
   delegate :key_with_suffixed_year, :key_with_year, to: :key
 
   has_many :reference_author_names, -> { order(:position) }, inverse_of: :reference, dependent: :destroy

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -17,7 +17,7 @@ class Reference < ApplicationRecord
   IGNORE_PAPER_TRAIL_COLUMNS = CACHE_COLUMNS
   SOLR_IGNORE_ATTRIBUTE_CHANGES_OF = CACHE_COLUMNS
 
-  delegate :routed_url, :downloadable?, to: :document, allow_nil: true
+  delegate :routed_url, to: :document, allow_nil: true
   delegate :key_with_suffixed_year, :key_with_year, to: :key
 
   has_many :reference_author_names, -> { order(:position) }, inverse_of: :reference, dependent: :destroy
@@ -68,6 +68,10 @@ class Reference < ApplicationRecord
     string(:stated_year)
     string(:doi)
     string(:author_names_string)
+  end
+
+  def downloadable?
+    !!document
   end
 
   # TODO: Something regarding "_cache" vs. "string" vs. not.

--- a/app/models/reference_document.rb
+++ b/app/models/reference_document.rb
@@ -31,11 +31,6 @@ class ReferenceDocument < ApplicationRecord
     true
   end
 
-  # TODO: Check and simplify callers now that all existing documents are downloadable.
-  def downloadable?
-    hosted_on_s3? || url.present?
-  end
-
   def actual_url
     hosted_on_s3? ? s3_url : url
   end

--- a/app/models/reference_document.rb
+++ b/app/models/reference_document.rb
@@ -6,7 +6,8 @@
 class ReferenceDocument < ApplicationRecord
   belongs_to :reference, optional: true # TODO: Probably require after cleaning up records.
 
-  validate :check_url, :ensure_url_has_protocol, :ensure_file_or_url_present
+  validates :url, absence: true, on: :create
+  validate :ensure_file_or_url_present
 
   has_attached_file :file,
     preserve_files: true,
@@ -67,24 +68,6 @@ class ReferenceDocument < ApplicationRecord
 
     def hosted_on_s3?
       file_file_name.present?
-    end
-
-    def check_url
-      return if Rails.env.development? # HACK
-      return if file_file_name.present? || url.blank?
-      # This is to avoid authentication problems when a URL to one of "our" files is copied
-      # to another reference (e.g., nested).
-      return if /antcat/.match?(url)
-
-      URI.parse(url.gsub(' ', '%20'))
-    rescue URI::InvalidURIError
-      errors.add :url, 'is not in a valid format'
-    end
-
-    def ensure_url_has_protocol
-      return if url.blank?
-      return if url.match?(%r{^https?://})
-      errors.add :url, 'must start with http:// or https://'
     end
 
     def url_via_file_file_name

--- a/app/views/references/_form.haml
+++ b/app/views/references/_form.haml
@@ -142,12 +142,13 @@
           .row
             .medium-12.columns
               =document_form.file_field :file
-          .row
-            .medium-12.columns.end
-              =f.label :document_url do
-                Source URL
-                =db_tooltip_icon :document_url, scope: :references
-              =document_form.text_field :url
+
+          -if document_form.object.url?
+            .row
+              .medium-12.columns.end
+                =f.label :document_url do
+                  Source URL (legacy)
+                =document_form.text_field :url
 
           .row.small-text
             .medium-12.columns

--- a/features/reference_form/edit_reference_successfully.feature
+++ b/features/reference_form/edit_reference_successfully.feature
@@ -46,14 +46,6 @@ Feature: Edit reference successfully
     And I press "Save"
     Then I should see "Fisher, B. 2010. Ants. New York: Wiley, 22 pp."
 
-  Scenario: Specifying the document URL
-    Given there is a reference
-
-    When I go to the edit page for the most recent reference
-    And I fill in "reference_document_attributes_url" with a URL to a document that exists
-    And I press "Save"
-    Then I should see a PDF link
-
   Scenario: Edit a `NestedReference`
     Given this article reference exists
       | author     | year | title | journal | series_volume_issue | pagination |

--- a/features/step_definitions/reference_steps.rb
+++ b/features/step_definitions/reference_steps.rb
@@ -60,10 +60,6 @@ When('I fill in "reference_nesting_reference_id" with the ID for {string}') do |
   step %(I fill in "reference_nesting_reference_id" with "#{reference.id}")
 end
 
-Then("I should see a PDF link") do
-  find "a", text: "PDF", match: :first
-end
-
 When("I fill in {string} with a URL to a document that exists") do |field_name|
   stub_request :any, "http://google.com/foo"
   step %(I fill in "#{field_name}" with "http://google\.com/foo")

--- a/public/api/v1/swagger.yaml
+++ b/public/api/v1/swagger.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 
 info:
-  version: "1.7.0"
+  version: "1.7.1"
   title: AntCat REST API
   description: Read only API to access antcat.org
   contact:
@@ -982,8 +982,6 @@ definitions:
       file_file_name:
         type: string
         description: Filename
-      public:
-        type: boolean
       created_at:
         type: string
         format: date-time

--- a/spec/controllers/api/v1/reference_documents_controller_spec.rb
+++ b/spec/controllers/api/v1/reference_documents_controller_spec.rb
@@ -6,8 +6,10 @@ describe Api::V1::ReferenceDocumentsController, as: :visitor do
   describe "GET index" do
     specify do
       reference_document = create :reference_document, :with_file
+
       get :index
-      expect(json_response).to eq([reference_document.as_json(root: true)])
+
+      expect(json_response).to eq([reference_document.as_json(root: true, only: described_class::ATTRIBUTES)])
     end
 
     specify { expect(get(:index)).to have_http_status :ok }
@@ -25,7 +27,6 @@ describe Api::V1::ReferenceDocumentsController, as: :visitor do
             "reference_id" => reference_document.reference.id,
             "file_file_name" => reference_document.file_file_name,
             "url" => reference_document.url,
-            "public" => reference_document.public,
 
             "created_at" => reference_document.created_at.as_json,
             "updated_at" => reference_document.updated_at.as_json

--- a/spec/controllers/references/downloads_controller_spec.rb
+++ b/spec/controllers/references/downloads_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe References::DownloadsController do
   describe "GET show", as: :visitor do
     context "when reference document is downloadable" do
-      let!(:reference_document) { create :reference_document, url: "http://localhost/file.pdf" }
+      let!(:reference_document) { create :reference_document, :with_file }
 
       it "redirects to the file" do
         get :show, params: { id: reference_document.id, file_name: "not_even_stubbed.pdf" }

--- a/spec/controllers/references/downloads_controller_spec.rb
+++ b/spec/controllers/references/downloads_controller_spec.rb
@@ -4,13 +4,11 @@ require 'rails_helper'
 
 describe References::DownloadsController do
   describe "GET show", as: :visitor do
-    context "when reference document is downloadable" do
-      let!(:reference_document) { create :reference_document, :with_file }
+    let!(:reference_document) { create :reference_document, :with_file }
 
-      it "redirects to the file" do
-        get :show, params: { id: reference_document.id, file_name: "not_even_stubbed.pdf" }
-        expect(response).to redirect_to reference_document.actual_url
-      end
+    it "redirects to the file" do
+      get :show, params: { id: reference_document.id, file_name: "not_even_stubbed.pdf" }
+      expect(response).to redirect_to reference_document.actual_url
     end
   end
 end

--- a/spec/decorators/reference_decorator_spec.rb
+++ b/spec/decorators/reference_decorator_spec.rb
@@ -28,7 +28,7 @@ describe ReferenceDecorator do
   describe "#format_document_links" do
     let(:reference) { build_stubbed :any_reference }
 
-    context 'when reference does not have document' do
+    context 'when reference does not have a document' do
       specify { expect(decorated.format_document_links).to eq nil }
     end
 

--- a/spec/factories/reference_documents.rb
+++ b/spec/factories/reference_documents.rb
@@ -7,6 +7,14 @@ FactoryBot.define do
       url { nil }
     end
 
+    trait :with_deprecated_url do
+      with_file
+
+      after(:create) do |reference_document, _evaluator|
+        reference_document.update!(url: 'http://localhost/document.pdf', file_file_name: nil)
+      end
+    end
+
     trait :with_reference do
       reference factory: :any_reference
     end

--- a/spec/forms/reference_form_spec.rb
+++ b/spec/forms/reference_form_spec.rb
@@ -245,14 +245,14 @@ describe ReferenceForm do
 
     describe 'reference documents' do
       context 'when creating a reference' do
-        context 'when no `file` or `url` is given' do
+        context 'when no `file` is uploaded' do
           let!(:reference) { build :article_reference }
           let(:params) do
             {
               author_names_string: "Batiatus, B.",
               journal_name: reference.journal.name,
               document_attributes: {
-                url: ""
+                file: ""
               }
             }
           end
@@ -267,7 +267,7 @@ describe ReferenceForm do
           end
         end
 
-        context 'when a `file` or `url` is given' do
+        context 'when a `file` is uploaded' do
           let!(:journal) { create :journal }
           let!(:reference) do
             ArticleReference.new(
@@ -283,7 +283,7 @@ describe ReferenceForm do
               author_names_string: "Batiatus, B.",
               journal_name: 'Zootaxa',
               document_attributes: {
-                url: "https://example.com/file.pdf"
+                file: File.new(Rails.root.join('spec/fixtures/test_pdf.pdf'))
               }
             }
           end
@@ -296,7 +296,7 @@ describe ReferenceForm do
             expect { described_class.new(reference, params).save }.to change { Reference.count }
           end
 
-          it 'does creates a new `ReferenceDocument`' do
+          it 'creates a new `ReferenceDocument`' do
             expect { described_class.new(reference, params).save }.
               to change { ReferenceDocument.count }.from(0).to(1)
           end

--- a/spec/forms/reference_form_spec.rb
+++ b/spec/forms/reference_form_spec.rb
@@ -252,8 +252,7 @@ describe ReferenceForm do
               author_names_string: "Batiatus, B.",
               journal_name: reference.journal.name,
               document_attributes: {
-                url: "",
-                public: '1'
+                url: ""
               }
             }
           end
@@ -283,10 +282,8 @@ describe ReferenceForm do
             {
               author_names_string: "Batiatus, B.",
               journal_name: 'Zootaxa',
-              bolton_key: 'Smith 1958',
               document_attributes: {
-                url: "https://example.com/file.pdf",
-                public: '1'
+                url: "https://example.com/file.pdf"
               }
             }
           end

--- a/spec/injectable_formatters/antweb_formatter/reference_link_spec.rb
+++ b/spec/injectable_formatters/antweb_formatter/reference_link_spec.rb
@@ -3,23 +3,22 @@
 require 'rails_helper'
 
 describe AntwebFormatter::ReferenceLink do
-  let!(:reference) do
-    create :article_reference,
-      :with_doi,
-      author_string: 'Latreille, P. A.',
-      year: 1809,
-      title: "*Atta*",
-      journal: create(:journal, name: 'Science'),
-      series_volume_issue: '(1)',
-      pagination: '3'
-  end
-
-  before { allow(reference).to receive(:routed_url).and_return 'example.com' }
-
   describe "#call" do
-    context "when PDF is not available to the user" do
-      it "doesn't include the PDF link" do
+    let(:reference) do
+      create :article_reference,
+        :with_doi,
+        author_string: 'Latreille, P. A.',
+        year: 1809,
+        title: "*Atta*",
+        journal: create(:journal, name: 'Science'),
+        series_volume_issue: '(1)',
+        pagination: '3'
+    end
+
+    context "when reference is not downloadable" do
+      specify do
         allow(reference).to receive(:downloadable?).and_return false
+        allow(reference).to receive(:routed_url).and_return 'example.com'
 
         expect(described_class[reference]).to eq(
           %{<a title="Latreille, P. A. 1809. Atta. Science (1):3." } +
@@ -29,9 +28,10 @@ describe AntwebFormatter::ReferenceLink do
       end
     end
 
-    context "when PDF is available to the user" do
+    context "when reference is downloadable" do
       it "includes the PDF link" do
         allow(reference).to receive(:downloadable?).and_return true
+        allow(reference).to receive(:routed_url).and_return 'example.com'
 
         expect(described_class[reference]).to eq(
           %{<a title="Latreille, P. A. 1809. Atta. Science (1):3." } +

--- a/spec/models/reference_document_spec.rb
+++ b/spec/models/reference_document_spec.rb
@@ -6,22 +6,7 @@ describe ReferenceDocument do
   it { is_expected.to be_versioned }
 
   describe 'validations' do
-    it "validates URLs start with a protocol" do
-      document = described_class.new(url: 'antwiki.org/url')
-      expect(document.valid?).to eq false
-    end
-
-    it "validates the URL" do
-      document = described_class.new(url: 'http://:::')
-      expect(document.valid?).to eq false
-      expect(document.errors.full_messages).to include 'Url is not in a valid format'
-    end
-
-    it "accepts URLs with spaces" do
-      stub_request(:any, "http://antwiki.org/a%20url").to_return(body: "Hello World!")
-      document = described_class.new(url: 'http://antwiki.org/a url')
-      expect(document.valid?).to eq true
-    end
+    it { is_expected.to validate_absence_of(:url).on(:create) }
 
     describe '#ensure_file_or_url_present' do
       context 'when `url` and `file_file_name` are both blank' do
@@ -54,15 +39,6 @@ describe ReferenceDocument do
       expect(document.reload.routed_url).to eq "http://antcat.org/documents/#{document.id}/1.pdf"
     end
 
-    context "when there is no file" do
-      let!(:document) { described_class.new }
-
-      specify do
-        expect(document.url).to eq nil
-        expect(document.routed_url).to eq document.url
-      end
-    end
-
     context "when the file isn't hosted by us" do
       let(:document) { described_class.new(url: 'foo') }
 
@@ -83,10 +59,10 @@ describe ReferenceDocument do
   end
 
   describe "#actual_url" do
-    let!(:document) { create :reference_document, url: 'http://localhost/document.pdf' }
+    let!(:reference_document) { create :reference_document, :with_deprecated_url }
 
-    it "simply be the url, if the document's not on Amazon" do
-      expect(document.reload.actual_url).to eq 'http://localhost/document.pdf'
+    it "simply is the `url`" do
+      expect(reference_document.reload.actual_url).to eq reference_document.url
     end
   end
 

--- a/spec/models/reference_document_spec.rb
+++ b/spec/models/reference_document_spec.rb
@@ -65,18 +65,4 @@ describe ReferenceDocument do
       expect(reference_document.reload.actual_url).to eq reference_document.url
     end
   end
-
-  describe "#downloadable?" do
-    context 'when reference has a `file_file_name`' do
-      let(:reference_document) { described_class.new(url: nil, file_file_name: 'file.pdf') }
-
-      specify { expect(reference_document.downloadable?).to eq true }
-    end
-
-    context 'when reference has a `url`' do
-      let(:reference_document) { described_class.new(url: "http://ancat.org/file.pdf", file_file_name: nil) }
-
-      specify { expect(reference_document.downloadable?).to eq true }
-    end
-  end
 end

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe Reference do
   it { is_expected.to be_versioned }
-  it { is_expected.to delegate_method(:routed_url).to(:document).allow_nil }
+  it { is_expected.to delegate_method(:routed_url).to(:document) }
 
   describe 'relations' do
     it { is_expected.to have_many(:reference_author_names).dependent(:destroy) }

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 describe Reference do
   it { is_expected.to be_versioned }
   it { is_expected.to delegate_method(:routed_url).to(:document).allow_nil }
-  it { is_expected.to delegate_method(:downloadable?).to(:document).allow_nil }
 
   describe 'relations' do
     it { is_expected.to have_many(:reference_author_names).dependent(:destroy) }
@@ -55,6 +54,20 @@ describe Reference do
 
         expect(described_class.order_by_author_names_and_year).to eq [three, one, two]
       end
+    end
+  end
+
+  describe '#downloadable?' do
+    context 'when referece has a `ReferenceDocument`' do
+      let(:reference) { create :any_reference, :with_document }
+
+      specify { expect(reference.downloadable?).to eq true }
+    end
+
+    context 'when referece does not have a `ReferenceDocument`' do
+      let(:reference) { create :any_reference }
+
+      specify { expect(reference.downloadable?).to eq false }
     end
   end
 


### PR DESCRIPTION
For https://github.com/calacademy-research/antcat-issues/issues/114