### PR TITLE
Add support for mirrored history items, and enable for `JuniorSynonymOf` items

### DIFF
--- a/app/models/grouped_history_item.rb
+++ b/app/models/grouped_history_item.rb
@@ -10,12 +10,15 @@ class GroupedHistoryItem
     @items = items
   end
 
-  def taxt
-    @_taxt ||= if groupable?
-                 any_item_in_group.item_template_to_taxt(grouped_item_taxts: grouped_item_taxts)
-               else
-                 any_item_in_group.to_taxt
-               end
+  def taxt template_name = :default
+    @_taxt_cache ||= {}
+
+    @_taxt_cache[template_name] ||=
+      if groupable?
+        any_item_in_group.item_template_to_taxt(template_name, grouped_item_taxts: grouped_item_taxts)
+      else
+        any_item_in_group.to_taxt template_name
+      end
   end
 
   def grouped?

--- a/app/models/grouped_history_item.rb
+++ b/app/models/grouped_history_item.rb
@@ -41,6 +41,6 @@ class GroupedHistoryItem
     end
 
     def grouped_item_taxts
-      items.map(&:groupable_item_template_to_taxt).join('; ')
+      items.map(&:groupable_template_to_taxt).join('; ')
     end
 end

--- a/app/models/history/definition.rb
+++ b/app/models/history/definition.rb
@@ -40,13 +40,12 @@ module History
                       end
     end
 
-    def item_template
-      type_attributes.fetch(:item_template)
-    end
+    def render_template template_name, history_item, vars = {}
+      template = type_attributes[:templates].fetch(template_name)
+      raise "missing template '#{template_name}'" unless template
 
-    def item_template_vars history_item
-      return {} unless (vars = type_attributes[:item_template_vars])
-      vars.call(history_item).symbolize_keys
+      template_vars = template[:vars].call(history_item).symbolize_keys if template[:vars]
+      template.fetch(:content) % (template_vars || {}).merge(vars)
     end
 
     def groupable_item_template

--- a/app/models/history/definition.rb
+++ b/app/models/history/definition.rb
@@ -30,14 +30,18 @@ module History
       type_attributes.fetch(:group_order)
     end
 
-    def group_key history_item
-      return @_group_key if defined?(@_group_key)
+    def group_key history_item, template_name
+      @_group_key_cache ||= {}
 
-      @_group_key ||= if (key = type_attributes.fetch(:group_key, nil))
-                        key.call(history_item)
-                      else
-                        history_item.id
-                      end
+      @_group_key_cache[template_name] ||= begin
+        template = type_attributes[:templates].fetch(template_name)
+
+        if (key = template[:group_key] || type_attributes.fetch(:group_key, nil))
+          key.call(history_item)
+        else
+          history_item.id
+        end
+      end
     end
 
     def render_template template_name, history_item, vars = {}

--- a/app/models/history/definition.rb
+++ b/app/models/history/definition.rb
@@ -48,12 +48,12 @@ module History
       template.fetch(:content) % (template_vars || {}).merge(vars)
     end
 
-    def groupable_item_template
-      @_groupable_item_template ||= type_attributes.fetch(:groupable_item_template, nil)
+    def groupable_template_content
+      @_groupable_template_content ||= type_attributes.fetch(:groupable_template_content, nil)
     end
 
-    def groupable_item_template_vars history_item
-      return {} unless (vars = type_attributes[:groupable_item_template_vars])
+    def groupable_template_vars history_item
+      return {} unless (vars = type_attributes[:groupable_template_vars])
       vars.call(history_item).symbolize_keys
     end
 

--- a/app/models/history/definitions.rb
+++ b/app/models/history/definitions.rb
@@ -109,6 +109,16 @@ module History
                 object_protonym_tag: o.force_author_citation? ? 'prottac' : 'prott'
               }
             }
+          },
+          object: {
+            content: 'Senior synonym of {%<subject_protonym_tag>s %<subject_protonym_id>i}: %<grouped_item_taxts>s.',
+            vars: ->(o) {
+              {
+                subject_protonym_id: o.protonym_id,
+                subject_protonym_tag: o.force_author_citation? ? 'prottac' : 'prott'
+              }
+            },
+            group_key: ->(o) { [o.type, 'as_object', 'subject_protonym_id', o.protonym_id] }
           }
         },
 
@@ -258,6 +268,10 @@ module History
         optional_attributes: [:reference, :pages]
       }
     }
+
     TYPES = TYPE_DEFINITIONS.keys
+    VISIBLE_AS_OBJECT = [
+      JUNIOR_SYNONYM_OF
+    ]
   end
 end

--- a/app/models/history/definitions.rb
+++ b/app/models/history/definitions.rb
@@ -66,8 +66,8 @@ module History
           }
         },
 
-        groupable_item_template: '%<citation>s (%<forms>s)',
-        groupable_item_template_vars: ->(o) { { citation: o.citation, forms: o.text_value } },
+        groupable_template_content: '%<citation>s (%<forms>s)',
+        groupable_template_vars: ->(o) { { citation: o.citation, forms: o.text_value } },
 
         validates_presence_of: [:text_value, :reference, :pages]
       },
@@ -86,8 +86,8 @@ module History
           }
         },
 
-        groupable_item_template: '%<citation>s',
-        groupable_item_template_vars: ->(o) { { citation: o.citation } },
+        groupable_template_content: '%<citation>s',
+        groupable_template_vars: ->(o) { { citation: o.citation } },
 
         validates_presence_of: [:object_taxon, :reference, :pages]
       },
@@ -112,8 +112,8 @@ module History
           }
         },
 
-        groupable_item_template: '%<citation>s',
-        groupable_item_template_vars: ->(o) { { citation: o.citation } },
+        groupable_template_content: '%<citation>s',
+        groupable_template_vars: ->(o) { { citation: o.citation } },
 
         validates_presence_of: [:object_protonym, :reference, :pages],
         allow_force_author_citation: true
@@ -139,8 +139,8 @@ module History
           }
         },
 
-        groupable_item_template: '%<citation>s',
-        groupable_item_template_vars: ->(o) { { citation: o.citation } },
+        groupable_template_content: '%<citation>s',
+        groupable_template_vars: ->(o) { { citation: o.citation } },
 
         validates_presence_of: [:object_protonym, :reference, :pages],
         allow_force_author_citation: true
@@ -159,8 +159,8 @@ module History
           }
         },
 
-        groupable_item_template: '%<citation>s',
-        groupable_item_template_vars: ->(o) { { citation: o.citation } },
+        groupable_template_content: '%<citation>s',
+        groupable_template_vars: ->(o) { { citation: o.citation } },
 
         validates_presence_of: [:reference, :pages]
       },
@@ -184,8 +184,8 @@ module History
           }
         },
 
-        groupable_item_template: '%<citation>s',
-        groupable_item_template_vars: ->(o) { { citation: o.citation } },
+        groupable_template_content: '%<citation>s',
+        groupable_template_vars: ->(o) { { citation: o.citation } },
 
         validates_presence_of: [:object_protonym, :reference, :pages],
         allow_force_author_citation: true

--- a/app/models/history/definitions.rb
+++ b/app/models/history/definitions.rb
@@ -19,7 +19,11 @@ module History
 
         group_order: 999,
 
-        item_template: '%<item_taxts>s',
+        templates: {
+          default: {
+            content: '%<item_taxts>s'
+          }
+        },
 
         validates_presence_of: [:taxt]
       },
@@ -30,8 +34,12 @@ module History
 
         group_order: 10,
 
-        item_template: '%<designation_type>s: %<citation>s.',
-        item_template_vars: ->(o) { { designation_type: o.subtype.underscore.humanize, citation: o.citation } },
+        templates: {
+          default: {
+            content: '%<designation_type>s: %<citation>s.',
+            vars: ->(o) { { designation_type: o.subtype.underscore.humanize, citation: o.citation } }
+          }
+        },
 
         subtypes: TYPE_SPECIMEN_DESIGNATION_SUBTYPES = [
           LECTOTYPE_DESIGNATION = 'LectotypeDesignation',
@@ -52,7 +60,11 @@ module History
         group_order: 20,
         group_key: ->(o) { o.type },
 
-        item_template: '%<grouped_item_taxts>s.',
+        templates: {
+          default: {
+            content: '%<grouped_item_taxts>s.'
+          }
+        },
 
         groupable_item_template: '%<citation>s (%<forms>s)',
         groupable_item_template_vars: ->(o) { { citation: o.citation, forms: o.text_value } },
@@ -67,8 +79,12 @@ module History
         group_order: 30,
         group_key: ->(o) { [o.type, 'object_taxon_id', o.object_taxon_id] },
 
-        item_template: 'Combination in {tax %<object_taxon_id>i}: %<grouped_item_taxts>s.',
-        item_template_vars: ->(o) { o.slice(:object_taxon_id) },
+        templates: {
+          default: {
+            content: 'Combination in {tax %<object_taxon_id>i}: %<grouped_item_taxts>s.',
+            vars: ->(o) { o.slice(:object_taxon_id) }
+          }
+        },
 
         groupable_item_template: '%<citation>s',
         groupable_item_template_vars: ->(o) { { citation: o.citation } },
@@ -84,11 +100,15 @@ module History
         group_order: 40,
         group_key: ->(o) { [o.type, 'object_protonym_id', o.object_protonym_id] },
 
-        item_template: 'Junior synonym of {%<object_protonym_tag>s %<object_protonym_id>i}: %<grouped_item_taxts>s.',
-        item_template_vars:  ->(o) {
-          {
-            object_protonym_id: o.object_protonym_id,
-            object_protonym_tag: o.force_author_citation? ? 'prottac' : 'prott'
+        templates: {
+          default: {
+            content: 'Junior synonym of {%<object_protonym_tag>s %<object_protonym_id>i}: %<grouped_item_taxts>s.',
+            vars: ->(o) {
+              {
+                object_protonym_id: o.object_protonym_id,
+                object_protonym_tag: o.force_author_citation? ? 'prottac' : 'prott'
+              }
+            }
           }
         },
 
@@ -107,11 +127,15 @@ module History
         group_order: 45,
         group_key: ->(o) { [o.type, 'object_protonym_id', o.object_protonym_id] },
 
-        item_template: 'Senior synonym of {%<object_protonym_tag>s %<object_protonym_id>i}: %<grouped_item_taxts>s.',
-        item_template_vars:  ->(o) {
-          {
-            object_protonym_id: o.object_protonym_id,
-            object_protonym_tag: o.force_author_citation? ? 'prottac' : 'prott'
+        templates: {
+          default: {
+            content: 'Senior synonym of {%<object_protonym_tag>s %<object_protonym_id>i}: %<grouped_item_taxts>s.',
+            vars:  ->(o) {
+              {
+                object_protonym_id: o.object_protonym_id,
+                object_protonym_tag: o.force_author_citation? ? 'prottac' : 'prott'
+              }
+            }
           }
         },
 
@@ -129,7 +153,11 @@ module History
         group_order: 50,
         group_key: ->(o) { [o.type] },
 
-        item_template: 'Status as species: %<grouped_item_taxts>s.',
+        templates: {
+          default: {
+            content: 'Status as species: %<grouped_item_taxts>s.'
+          }
+        },
 
         groupable_item_template: '%<citation>s',
         groupable_item_template_vars: ->(o) { { citation: o.citation } },
@@ -144,11 +172,15 @@ module History
         group_order: 60,
         group_key: ->(o) { [o.type, 'object_protonym_id', o.object_protonym_id] },
 
-        item_template: 'Subspecies of {%<object_protonym_tag>s %<object_protonym_id>i}: %<grouped_item_taxts>s.',
-        item_template_vars:  ->(o) {
-          {
-            object_protonym_id: o.object_protonym_id,
-            object_protonym_tag: o.force_author_citation? ? 'prottac' : 'prott'
+        templates: {
+          default: {
+            content: 'Subspecies of {%<object_protonym_tag>s %<object_protonym_id>i}: %<grouped_item_taxts>s.',
+            vars:  ->(o) {
+              {
+                object_protonym_id: o.object_protonym_id,
+                object_protonym_tag: o.force_author_citation? ? 'prottac' : 'prott'
+              }
+            }
           }
         },
 
@@ -165,11 +197,15 @@ module History
 
         group_order: 70,
 
-        item_template: 'Replacement name: {prottac %<object_protonym_id>i}%<citation>s.',
-        item_template_vars: ->(o) {
-          {
-            object_protonym_id: o.object_protonym_id,
-            citation: (" (#{o.citation})" if o.citation)
+        templates: {
+          default: {
+            content: 'Replacement name: {prottac %<object_protonym_id>i}%<citation>s.',
+            vars: ->(o) {
+              {
+                object_protonym_id: o.object_protonym_id,
+                citation: (" (#{o.citation})" if o.citation)
+              }
+            }
           }
         },
 
@@ -183,12 +219,16 @@ module History
 
         group_order: 75,
 
-        item_template: 'Replacement name for {prottac %<object_protonym_id>i}%<citation>s.%<legacy_taxt>s',
-        item_template_vars: ->(o) {
-          {
-            object_protonym_id: o.object_protonym_id,
-            citation: (" (#{o.citation})" if o.citation),
-            legacy_taxt: (" #{o.taxt}" if o.taxt?)
+        templates: {
+          default: {
+            content: 'Replacement name for {prottac %<object_protonym_id>i}%<citation>s.%<legacy_taxt>s',
+            vars: ->(o) {
+              {
+                object_protonym_id: o.object_protonym_id,
+                citation: (" (#{o.citation})" if o.citation),
+                legacy_taxt: (" #{o.taxt}" if o.taxt?)
+              }
+            }
           }
         },
 
@@ -202,11 +242,15 @@ module History
 
         group_order: 100,
 
-        item_template: 'Unavailable name%<citation>s.',
-        item_template_vars: ->(o) {
-          {
-            object_taxon_id: o.object_taxon_id,
-            citation: (" (#{o.citation})" if o.citation)
+        templates: {
+          default: {
+            content: 'Unavailable name%<citation>s.',
+            vars: ->(o) {
+              {
+                object_taxon_id: o.object_taxon_id,
+                citation: (" (#{o.citation})" if o.citation)
+              }
+            }
           }
         },
 

--- a/app/models/history_item.rb
+++ b/app/models/history_item.rb
@@ -83,20 +83,20 @@ class HistoryItem < ApplicationRecord
     !taxt_type?
   end
 
-  def to_taxt
+  def to_taxt template_name = :default
     return taxt if taxt_type?
 
     if groupable?
-      item_template_to_taxt grouped_item_taxts: groupable_item_template_to_taxt
+      item_template_to_taxt template_name, grouped_item_taxts: groupable_item_template_to_taxt
     else
-      item_template_to_taxt
+      item_template_to_taxt template_name
     end
   end
 
-  def item_template_to_taxt vars = {}
+  def item_template_to_taxt template_name, vars = {}
     return taxt if taxt_type?
 
-    item_template % item_template_vars(self).merge(vars)
+    definition.render_template(template_name, self, vars)
   end
 
   def groupable_item_template_to_taxt
@@ -129,7 +129,7 @@ class HistoryItem < ApplicationRecord
 
   private
 
-    delegate :item_template, :item_template_vars, :groupable_item_template, :groupable_item_template_vars,
+    delegate :groupable_item_template, :groupable_item_template_vars,
       :optional_attributes, to: :definition, private: true
 
     def cleanup_and_convert_taxts

--- a/app/models/history_item.rb
+++ b/app/models/history_item.rb
@@ -56,6 +56,7 @@ class HistoryItem < ApplicationRecord
 
   scope :relational, -> { where.not(type: History::Definitions::TAXT) }
   scope :taxts_only, -> { where(type: History::Definitions::TAXT) }
+  scope :visible_as_object, -> { where(type: History::Definitions::VISIBLE_AS_OBJECT) }
 
   # Type scopes (the "_relitems" suffixes were added to make greping easier).
   scope :combination_in_relitems, -> { where(type: History::Definitions::COMBINATION_IN) }
@@ -111,8 +112,8 @@ class HistoryItem < ApplicationRecord
   end
   alias_method :citation, :citation_taxt
 
-  def group_key
-    definition.group_key(self)
+  def group_key template_name = :default
+    definition.group_key(self, template_name)
   end
 
   def ids_from_taxon_tags

--- a/app/models/history_item.rb
+++ b/app/models/history_item.rb
@@ -87,7 +87,7 @@ class HistoryItem < ApplicationRecord
     return taxt if taxt_type?
 
     if groupable?
-      item_template_to_taxt template_name, grouped_item_taxts: groupable_item_template_to_taxt
+      item_template_to_taxt template_name, grouped_item_taxts: groupable_template_to_taxt
     else
       item_template_to_taxt template_name
     end
@@ -99,8 +99,8 @@ class HistoryItem < ApplicationRecord
     definition.render_template(template_name, self, vars)
   end
 
-  def groupable_item_template_to_taxt
-    groupable_item_template % groupable_item_template_vars(self)
+  def groupable_template_to_taxt
+    groupable_template_content % groupable_template_vars(self)
   end
 
   def citation_taxt
@@ -129,7 +129,7 @@ class HistoryItem < ApplicationRecord
 
   private
 
-    delegate :groupable_item_template, :groupable_item_template_vars,
+    delegate :groupable_template_content, :groupable_template_vars,
       :optional_attributes, to: :definition, private: true
 
     def cleanup_and_convert_taxts

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -30,6 +30,9 @@ class Taxon < ApplicationRecord
   has_many :protonym_history_items, through: :protonym, source: :history_items
   has_many :history_items_for_taxon_including_hidden, ->(taxon) { unranked_and_for_rank(taxon.type) },
     through: :protonym, source: :history_items
+  has_many :history_items_as_object_for_taxon_including_hidden,
+    ->(taxon) { visible_as_object.unranked_and_for_rank(taxon.type) },
+    through: :protonym, source: :history_items_as_object
 
   validates :status, inclusion: { in: Status::STATUSES }
   validates :incertae_sedis_in, inclusion: { in: Rank::INCERTAE_SEDIS_IN_TYPES, allow_nil: true }
@@ -125,6 +128,11 @@ class Taxon < ApplicationRecord
   def history_items_for_taxon
     return HistoryItem.none unless Status.display_history_items?(status)
     history_items_for_taxon_including_hidden
+  end
+
+  def history_items_as_object_for_taxon
+    return HistoryItem.none unless Status.display_history_items?(status)
+    history_items_as_object_for_taxon_including_hidden
   end
 
   def taxon_collaborators

--- a/app/presenters/history_presenter.rb
+++ b/app/presenters/history_presenter.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class HistoryPresenter
-  attr_private_initialize :history_items
+  def initialize history_items, template_name = :default
+    @history_items = history_items
+    @template_name = template_name
+  end
 
   def grouped_items
     @_grouped_items ||= grouped_items_array.map do |items|
@@ -10,6 +13,8 @@ class HistoryPresenter
   end
 
   private
+
+    attr_reader :history_items, :template_name
 
     def grouped_items_array
       items = history_items.left_joins(:reference).
@@ -21,6 +26,6 @@ class HistoryPresenter
           (item.reference_year || -1),
           (Integer(item.reference_date, exception: false) || -1).to_s
         ]
-      end.group_by { |item| item.group_key }.values
+      end.group_by { |item| item.group_key(template_name) }.values
     end
 end

--- a/app/views/catalog/_show/_taxon_description.haml
+++ b/app/views/catalog/_show/_taxon_description.haml
@@ -58,7 +58,19 @@
       =replaced_name.author_citation
     =info_tooltip_icon "Via 'taxa.homonym_replaced_by_id'"
 
--# Grouped items.
+-# History items as object.
+-if current_user
+  -if taxon.history_items_as_object_for_taxon.present?
+    -history_presenter = HistoryPresenter.new(taxon.history_items_as_object_for_taxon, :object)
+
+    .callout.no-border-callout.logged-in-only-background.margin-top.margin-bottom
+      %strong History items as object (mirrored items)
+      %ul#history.small-margin-bottom
+        -history_presenter.grouped_items.each do |grouped_item|
+          %li
+            =Detax[grouped_item.taxt(:object)]
+
+-# Grouped history items.
 -if taxon.history_items_for_taxon.present?
   -history_presenter = HistoryPresenter.new(taxon.history_items_for_taxon)
 

--- a/spec/models/history/definitions_spec.rb
+++ b/spec/models/history/definitions_spec.rb
@@ -12,7 +12,8 @@ describe History::Definitions, :relational_hi do
 
           expect(definition[:group_order]).to be_present
 
-          expect(definition[:item_template]).to be_present
+          expect(definition[:templates]).to be_present
+          expect(definition[:templates][:default]).to be_present
 
           expect(definition[:validates_presence_of]).to_not eq nil
         end

--- a/spec/models/history_item_spec.rb
+++ b/spec/models/history_item_spec.rb
@@ -338,6 +338,15 @@ describe HistoryItem, :relational_hi do
             to eq "Junior synonym of {#{Taxt::PROTTAC_TAG} #{history_item.object_protonym.id}}: #{history_item.citation_taxt}."
         end
       end
+
+      context 'with `object` template' do
+        let(:history_item) { create :history_item, :junior_synonym_of }
+
+        specify do
+          expect(history_item.to_taxt(:object)).
+            to eq "Senior synonym of {#{Taxt::PROTT_TAG} #{history_item.protonym.id}}: #{history_item.citation_taxt}."
+        end
+      end
     end
 
     context 'when `type` is `SENIOR_SYNONYM_OF`' do

--- a/spec/presenters/history_presenter_spec.rb
+++ b/spec/presenters/history_presenter_spec.rb
@@ -3,10 +3,9 @@
 require 'rails_helper'
 
 describe HistoryPresenter, :relational_hi do
-  subject(:presenter) { described_class.new(history_items) }
+  subject(:presenter) { described_class.new(protonym.history_items) }
 
   let(:protonym) { create :protonym }
-  let(:history_items) { protonym.history_items }
 
   describe "#grouped_items" do
     context 'without history items' do
@@ -88,9 +87,21 @@ describe HistoryPresenter, :relational_hi do
           create :history_item, :junior_synonym_of, :with_1758_reference,
             protonym: protonym, object_protonym: object_protonym
         end
+        let!(:item_3) do
+          create :history_item, :junior_synonym_of, :with_1758_reference,
+            protonym: protonym
+        end
 
         it 'groups them by `object_protonym`' do
-          expect(presenter.grouped_items.map(&:items)).to eq [[item_2, item_1]]
+          expect(presenter.grouped_items.map(&:items)).to eq [[item_2, item_1], [item_3]]
+        end
+
+        context 'with `object` template' do
+          subject(:presenter) { described_class.new(object_protonym.history_items_as_object, :object) }
+
+          it 'groups them by `protonym` (subject protonym)' do
+            expect(presenter.grouped_items.map(&:items)).to eq [[item_2, item_1]]
+          end
         end
       end
 
@@ -226,7 +237,7 @@ describe HistoryPresenter, :relational_hi do
 
         it 'sort taxt items by their position' do
           # Make sure positions are not auto updated for this spec.
-          expect(history_items.pluck(:id, :position, :taxt)).to eq [
+          expect(protonym.history_items.pluck(:id, :position, :taxt)).to eq [
             [item_2.id, 1, 'pos 1'],
             [item_3.id, 2, 'pos 2'],
             [item_1.id, 3, 'pos 3']


### PR DESCRIPTION
For https://github.com/calacademy-research/antcat-issues/issues/19