### PR TITLE
Start deduping inferrable taxon relations (subtribes/subgenera/subspecies/infraspecies)

### DIFF
--- a/app/database_scripts/database_scripts/taxa_with_disagreeing_taxon_relations.rb
+++ b/app/database_scripts/database_scripts/taxa_with_disagreeing_taxon_relations.rb
@@ -5,7 +5,6 @@ module DatabaseScripts
     def empty?
       !(
         # subfamily_id.
-        subfamily_id_of_subtribe_vs_tribe.exists? ||
         subfamily_id_of_genus_vs_tribe.exists? ||
         subfamily_id_of_subgenus_vs_genus.exists? ||
         subfamily_id_of_species_vs_genus.exists? ||
@@ -23,10 +22,6 @@ module DatabaseScripts
     end
 
     # subfamily_id.
-    def subfamily_id_of_subtribe_vs_tribe
-      Subtribe.joins(:tribe).where("tribes_taxa.subfamily_id != taxa.subfamily_id")
-    end
-
     def subfamily_id_of_genus_vs_tribe
       Genus.joins(:tribe).where("tribes_taxa.subfamily_id != taxa.subfamily_id")
     end
@@ -67,8 +62,7 @@ module DatabaseScripts
 
     def render
       # subfamily_id.
-      render_table(subfamily_id_of_subtribe_vs_tribe, "subtribe", :subfamily, :tribe) +
-        render_table(subfamily_id_of_genus_vs_tribe, "genus", :subfamily, :tribe) +
+      render_table(subfamily_id_of_genus_vs_tribe, "genus", :subfamily, :tribe) +
         render_table(subfamily_id_of_subgenus_vs_genus, "subgenus", :subfamily, :genus) +
         render_table(subfamily_id_of_species_vs_genus, "species", :subfamily, :genus) +
         render_table(subfamily_id_of_subspecies_vs_species, "subspecies", :subfamily, :species) +

--- a/app/database_scripts/database_scripts/taxa_with_disagreeing_taxon_relations.rb
+++ b/app/database_scripts/database_scripts/taxa_with_disagreeing_taxon_relations.rb
@@ -20,10 +20,6 @@ module DatabaseScripts
         genus_id_of_subspecies_vs_species.exists? ||
         genus_id_of_infrasubspecies_vs_subspecies.exists? ||
 
-        # subgenus_id.
-        subgenus_id_of_subspecies_vs_species.exists? ||
-        subgenus_id_of_infrasubspecies_vs_subspecies.exists? ||
-
         # species_id.
         species_id_of_infrasubspecies_vs_subspecies.exists?
       )
@@ -72,15 +68,6 @@ module DatabaseScripts
       Infrasubspecies.joins(:subspecies).where("subspecies_taxa.genus_id != taxa.genus_id")
     end
 
-    # subgenus_id.
-    def subgenus_id_of_subspecies_vs_species
-      Subspecies.joins(:species).where("species_taxa.subgenus_id != taxa.subgenus_id")
-    end
-
-    def subgenus_id_of_infrasubspecies_vs_subspecies
-      Infrasubspecies.joins(:subspecies).where("subspecies_taxa.subgenus_id != taxa.subgenus_id")
-    end
-
     # species_id.
     def species_id_of_infrasubspecies_vs_subspecies
       Infrasubspecies.joins(:subspecies).where("subspecies_taxa.species_id != taxa.species_id")
@@ -102,10 +89,6 @@ module DatabaseScripts
         render_table(genus_id_of_species_vs_subgenus, "species", :genus, :subgenus) +
         render_table(genus_id_of_subspecies_vs_species, "subspecies", :genus, :species) +
         render_table(genus_id_of_infrasubspecies_vs_subspecies, "infrasubspecies", :genus, :subspecies) +
-
-        # subgenus_id.
-        render_table(subgenus_id_of_subspecies_vs_species, "subspecies", :subgenus, :species) +
-        render_table(subgenus_id_of_infrasubspecies_vs_subspecies, "infrasubspecies", :subgenus, :subspecies) +
 
         # species_id.
         render_table(species_id_of_infrasubspecies_vs_subspecies, "infrasubspecies", :species, :subspecies)

--- a/app/database_scripts/database_scripts/taxa_with_disagreeing_taxon_relations.rb
+++ b/app/database_scripts/database_scripts/taxa_with_disagreeing_taxon_relations.rb
@@ -12,9 +12,17 @@ module DatabaseScripts
         subfamily_id_of_subspecies_vs_species.exists? ||
         subfamily_id_of_infrasubspecies_vs_subspecies.exists? ||
 
+        # tribe_id.
+        tribe_id_of_subgenus_vs_genus.exists? ||
+
         # genus_id.
+        genus_id_of_species_vs_subgenus.exists? ||
         genus_id_of_subspecies_vs_species.exists? ||
         genus_id_of_infrasubspecies_vs_subspecies.exists? ||
+
+        # subgenus_id.
+        subgenus_id_of_subspecies_vs_species.exists? ||
+        subgenus_id_of_infrasubspecies_vs_subspecies.exists? ||
 
         # species_id.
         species_id_of_infrasubspecies_vs_subspecies.exists?
@@ -46,13 +54,31 @@ module DatabaseScripts
       Infrasubspecies.joins(:subspecies).where("subspecies_taxa.subfamily_id != taxa.subfamily_id")
     end
 
+    # tribe_id.
+    def tribe_id_of_subgenus_vs_genus
+      Subgenus.joins(:genus).where("genera_taxa.tribe_id != taxa.tribe_id")
+    end
+
     # genus_id.
+    def genus_id_of_species_vs_subgenus
+      Species.joins(:subgenus).where("subgenera_taxa.genus_id != taxa.genus_id")
+    end
+
     def genus_id_of_subspecies_vs_species
       Subspecies.joins(:species).where("species_taxa.genus_id != taxa.genus_id")
     end
 
     def genus_id_of_infrasubspecies_vs_subspecies
       Infrasubspecies.joins(:subspecies).where("subspecies_taxa.genus_id != taxa.genus_id")
+    end
+
+    # subgenus_id.
+    def subgenus_id_of_subspecies_vs_species
+      Subspecies.joins(:species).where("species_taxa.subgenus_id != taxa.subgenus_id")
+    end
+
+    def subgenus_id_of_infrasubspecies_vs_subspecies
+      Infrasubspecies.joins(:subspecies).where("subspecies_taxa.subgenus_id != taxa.subgenus_id")
     end
 
     # species_id.
@@ -69,9 +95,17 @@ module DatabaseScripts
         render_table(subfamily_id_of_subspecies_vs_species, "subspecies", :subfamily, :species) +
         render_table(subfamily_id_of_infrasubspecies_vs_subspecies, "infrasubspecies", :subfamily, :subspecies) +
 
+        # tribe_id.
+        render_table(tribe_id_of_subgenus_vs_genus, "subgenus", :tribe, :genus) +
+
         # genus_id.
+        render_table(genus_id_of_species_vs_subgenus, "species", :genus, :subgenus) +
         render_table(genus_id_of_subspecies_vs_species, "subspecies", :genus, :species) +
         render_table(genus_id_of_infrasubspecies_vs_subspecies, "infrasubspecies", :genus, :subspecies) +
+
+        # subgenus_id.
+        render_table(subgenus_id_of_subspecies_vs_species, "subspecies", :subgenus, :species) +
+        render_table(subgenus_id_of_infrasubspecies_vs_subspecies, "infrasubspecies", :subgenus, :subspecies) +
 
         # species_id.
         render_table(species_id_of_infrasubspecies_vs_subspecies, "infrasubspecies", :species, :subspecies)

--- a/app/database_scripts/database_scripts/taxa_with_disagreeing_taxon_relations.rb
+++ b/app/database_scripts/database_scripts/taxa_with_disagreeing_taxon_relations.rb
@@ -12,9 +12,6 @@ module DatabaseScripts
         subfamily_id_of_subspecies_vs_species.exists? ||
         subfamily_id_of_infrasubspecies_vs_subspecies.exists? ||
 
-        # tribe_id.
-        tribe_id_of_subgenus_vs_genus.exists? ||
-
         # genus_id.
         genus_id_of_species_vs_subgenus.exists? ||
         genus_id_of_subspecies_vs_species.exists? ||
@@ -50,11 +47,6 @@ module DatabaseScripts
       Infrasubspecies.joins(:subspecies).where("subspecies_taxa.subfamily_id != taxa.subfamily_id")
     end
 
-    # tribe_id.
-    def tribe_id_of_subgenus_vs_genus
-      Subgenus.joins(:genus).where("genera_taxa.tribe_id != taxa.tribe_id")
-    end
-
     # genus_id.
     def genus_id_of_species_vs_subgenus
       Species.joins(:subgenus).where("subgenera_taxa.genus_id != taxa.genus_id")
@@ -81,9 +73,6 @@ module DatabaseScripts
         render_table(subfamily_id_of_species_vs_genus, "species", :subfamily, :genus) +
         render_table(subfamily_id_of_subspecies_vs_species, "subspecies", :subfamily, :species) +
         render_table(subfamily_id_of_infrasubspecies_vs_subspecies, "infrasubspecies", :subfamily, :subspecies) +
-
-        # tribe_id.
-        render_table(tribe_id_of_subgenus_vs_genus, "subgenus", :tribe, :genus) +
 
         # genus_id.
         render_table(genus_id_of_species_vs_subgenus, "species", :genus, :subgenus) +

--- a/app/models/taxon.rb
+++ b/app/models/taxon.rb
@@ -3,6 +3,16 @@
 class Taxon < ApplicationRecord
   include Trackable
 
+  TAXA_COLUMNS = [
+    :family_id,
+    :subfamily_id,
+    :tribe_id,
+    :genus_id,
+    :subgenus_id,
+    :species_id,
+    :subspecies_id
+  ]
+
   self.table_name = :taxa
 
   delegate :policy, :soft_validations, :what_links_here, to: :taxon_collaborators

--- a/app/models/taxon_sti_subclasses/family.rb
+++ b/app/models/taxon_sti_subclasses/family.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Family < Taxon
+  validates(*TAXA_COLUMNS, absence: true)
+
   def parent
   end
 

--- a/app/models/taxon_sti_subclasses/genus_group_taxon.rb
+++ b/app/models/taxon_sti_subclasses/genus_group_taxon.rb
@@ -2,7 +2,6 @@
 
 class GenusGroupTaxon < Taxon
   belongs_to :subfamily, optional: true
-  belongs_to :tribe, optional: true
 
   # TODO: Probably get rid of all `#children` and `#childrens_rank_in_words` in all classes,
   # or rename (like "direct_children" or "direct_descendants").

--- a/app/models/taxon_sti_subclasses/genus_group_taxon_sti_subclasses/genus.rb
+++ b/app/models/taxon_sti_subclasses/genus_group_taxon_sti_subclasses/genus.rb
@@ -19,6 +19,8 @@ class Genus < GenusGroupTaxon
   scope :without_subfamily, -> { where(subfamily_id: nil) }
   scope :without_tribe, -> { where(tribe_id: nil) }
 
+  validates(*(TAXA_COLUMNS - [:subfamily_id, :tribe_id]), absence: true)
+
   def parent
     tribe || subfamily || Family.first
   end

--- a/app/models/taxon_sti_subclasses/genus_group_taxon_sti_subclasses/subgenus.rb
+++ b/app/models/taxon_sti_subclasses/genus_group_taxon_sti_subclasses/subgenus.rb
@@ -5,6 +5,8 @@ class Subgenus < GenusGroupTaxon
 
   has_many :species, dependent: :restrict_with_error
 
+  validates(*(TAXA_COLUMNS - [:subfamily_id, :tribe_id, :genus_id]), absence: true)
+
   def parent
     genus
   end

--- a/app/models/taxon_sti_subclasses/genus_group_taxon_sti_subclasses/subgenus.rb
+++ b/app/models/taxon_sti_subclasses/genus_group_taxon_sti_subclasses/subgenus.rb
@@ -5,7 +5,7 @@ class Subgenus < GenusGroupTaxon
 
   has_many :species, dependent: :restrict_with_error
 
-  validates(*(TAXA_COLUMNS - [:subfamily_id, :tribe_id, :genus_id]), absence: true)
+  validates(*(TAXA_COLUMNS - [:subfamily_id, :genus_id]), absence: true)
 
   def parent
     genus

--- a/app/models/taxon_sti_subclasses/species_group_taxon.rb
+++ b/app/models/taxon_sti_subclasses/species_group_taxon.rb
@@ -3,7 +3,6 @@
 class SpeciesGroupTaxon < Taxon
   belongs_to :subfamily, optional: true
   belongs_to :genus
-  belongs_to :subgenus, optional: true
 
   validate :ensure_protonym_is_a_species_group_name
 

--- a/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/infrasubspecies.rb
+++ b/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/infrasubspecies.rb
@@ -6,6 +6,8 @@ class Infrasubspecies < SpeciesGroupTaxon
 
   validates :status, inclusion: { in: Status::STATUSES - [Status::VALID], message: 'is not allowed for rank.' }
 
+  validates(*(TAXA_COLUMNS - [:subfamily_id, :genus_id, :subgenus_id, :species_id, :subspecies_id]), absence: true)
+
   def parent
     subspecies
   end

--- a/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/infrasubspecies.rb
+++ b/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/infrasubspecies.rb
@@ -17,7 +17,6 @@ class Infrasubspecies < SpeciesGroupTaxon
 
     self.subfamily = parent_taxon.subfamily
     self.genus = parent_taxon.genus
-    self.subgenus = parent_taxon.subgenus
     self.species = parent_taxon.species
     self.subspecies = parent_taxon
   end

--- a/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/infrasubspecies.rb
+++ b/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/infrasubspecies.rb
@@ -6,7 +6,7 @@ class Infrasubspecies < SpeciesGroupTaxon
 
   validates :status, inclusion: { in: Status::STATUSES - [Status::VALID], message: 'is not allowed for rank.' }
 
-  validates(*(TAXA_COLUMNS - [:subfamily_id, :genus_id, :subgenus_id, :species_id, :subspecies_id]), absence: true)
+  validates(*(TAXA_COLUMNS - [:subfamily_id, :genus_id, :species_id, :subspecies_id]), absence: true)
 
   def parent
     subspecies

--- a/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/species.rb
+++ b/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/species.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Species < SpeciesGroupTaxon
+  belongs_to :subgenus, optional: true
+
   has_many :subspecies, dependent: :restrict_with_error
   has_many :infrasubspecies, dependent: :restrict_with_error
 

--- a/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/species.rb
+++ b/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/species.rb
@@ -6,6 +6,8 @@ class Species < SpeciesGroupTaxon
 
   scope :without_subgenus, -> { where(subgenus_id: nil) }
 
+  validates(*(TAXA_COLUMNS - [:subfamily_id, :genus_id, :subgenus_id]), absence: true)
+
   def parent
     subgenus || genus
   end

--- a/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/subspecies.rb
+++ b/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/subspecies.rb
@@ -5,7 +5,7 @@ class Subspecies < SpeciesGroupTaxon
 
   has_many :infrasubspecies, dependent: :restrict_with_error
 
-  validates(*(TAXA_COLUMNS - [:subfamily_id, :genus_id, :subgenus_id, :species_id]), absence: true)
+  validates(*(TAXA_COLUMNS - [:subfamily_id, :genus_id, :species_id]), absence: true)
 
   def parent
     species

--- a/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/subspecies.rb
+++ b/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/subspecies.rb
@@ -16,7 +16,6 @@ class Subspecies < SpeciesGroupTaxon
 
     self.subfamily = parent_taxon.subfamily
     self.genus = parent_taxon.genus
-    self.subgenus = parent_taxon.subgenus
     self.species = parent_taxon
   end
 

--- a/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/subspecies.rb
+++ b/app/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/subspecies.rb
@@ -5,6 +5,8 @@ class Subspecies < SpeciesGroupTaxon
 
   has_many :infrasubspecies, dependent: :restrict_with_error
 
+  validates(*(TAXA_COLUMNS - [:subfamily_id, :genus_id, :subgenus_id, :species_id]), absence: true)
+
   def parent
     species
   end

--- a/app/models/taxon_sti_subclasses/subfamily.rb
+++ b/app/models/taxon_sti_subclasses/subfamily.rb
@@ -14,6 +14,8 @@ class Subfamily < Taxon
   # TODO: See note in `Family` regarding incertae sedis.
   has_many :genera_incertae_sedis_in, -> { incertae_sedis_in_subfamily }, class_name: Rank::GENUS
 
+  validates(*(TAXA_COLUMNS - [:family_id]), absence: true)
+
   def parent
     Family.first
   end

--- a/app/models/taxon_sti_subclasses/subtribe.rb
+++ b/app/models/taxon_sti_subclasses/subtribe.rb
@@ -6,6 +6,8 @@ class Subtribe < Taxon
   belongs_to :subfamily
   belongs_to :tribe
 
+  validates(*(TAXA_COLUMNS - [:subfamily_id, :tribe_id]), absence: true)
+
   # TMPCLEANUP: Added here for now while refactoring and cleaning up data. Not sure where it really belongs.
   # NOTE: This method is more like "not_invalid_subtribe_name?", since validations already
   # present in `Name` (like valid characters) are not repeated here.

--- a/app/models/taxon_sti_subclasses/subtribe.rb
+++ b/app/models/taxon_sti_subclasses/subtribe.rb
@@ -3,10 +3,9 @@
 class Subtribe < Taxon
   VALID_ENDINGS_REGEX = /(ina|iti)\z/
 
-  belongs_to :subfamily
   belongs_to :tribe
 
-  validates(*(TAXA_COLUMNS - [:subfamily_id, :tribe_id]), absence: true)
+  validates(*(TAXA_COLUMNS - [:tribe_id]), absence: true)
 
   # TMPCLEANUP: Added here for now while refactoring and cleaning up data. Not sure where it really belongs.
   # NOTE: This method is more like "not_invalid_subtribe_name?", since validations already

--- a/app/models/taxon_sti_subclasses/tribe.rb
+++ b/app/models/taxon_sti_subclasses/tribe.rb
@@ -9,6 +9,8 @@ class Tribe < Taxon
     has_many :species, through: :genera
   end
 
+  validates(*(TAXA_COLUMNS - [:subfamily_id]), absence: true)
+
   def parent
     subfamily
   end

--- a/spec/exporters/exporters/antweb/taxonomic_attributes_spec.rb
+++ b/spec/exporters/exporters/antweb/taxonomic_attributes_spec.rb
@@ -163,7 +163,7 @@ describe Exporters::Antweb::TaxonomicAttributes do
           let(:species) { create :species, name_string: 'Atta robustus', genus: genus, subgenus: subgenus }
           let(:taxon) do
             create :subspecies, name_string: 'Atta robustus emeryii', subfamily: subfamily,
-              genus: genus, subgenus: subgenus, species: species
+              genus: genus, species: species
           end
 
           it 'exports the subgenus as the subgenus part of the name' do

--- a/spec/exporters/exporters/antweb/taxonomic_attributes_spec.rb
+++ b/spec/exporters/exporters/antweb/taxonomic_attributes_spec.rb
@@ -110,7 +110,7 @@ describe Exporters::Antweb::TaxonomicAttributes do
 
         context 'when species has a subgenus' do
           let(:genus) { create :genus, subfamily: subfamily, tribe: tribe }
-          let(:subgenus) { create :subgenus, name_string: 'Atta (Subgenusia)', subfamily: subfamily, tribe: tribe, genus: genus }
+          let(:subgenus) { create :subgenus, name_string: 'Atta (Subgenusia)', subfamily: subfamily, genus: genus }
           let(:taxon) { create :species, name_string: 'Atta robustus', genus: genus, subgenus: subgenus }
 
           it 'exports the subgenus as the subgenus part of the name' do
@@ -159,7 +159,7 @@ describe Exporters::Antweb::TaxonomicAttributes do
 
         context 'when subspecies has a subgenus' do
           let(:genus) { create :genus, subfamily: subfamily, tribe: tribe }
-          let(:subgenus) { create :subgenus, name_string: 'Atta (Subgenusia)', subfamily: subfamily, tribe: tribe, genus: genus }
+          let(:subgenus) { create :subgenus, name_string: 'Atta (Subgenusia)', subfamily: subfamily, genus: genus }
           let(:species) { create :species, name_string: 'Atta robustus', genus: genus, subgenus: subgenus }
           let(:taxon) do
             create :subspecies, name_string: 'Atta robustus emeryii', subfamily: subfamily,

--- a/spec/factories/taxa.rb
+++ b/spec/factories/taxa.rb
@@ -47,7 +47,6 @@ FactoryBot.define do
     factory :subtribe, class: Rank::SUBTRIBE.to_s do
       association :name, factory: :subtribe_name
       tribe
-      subfamily { |taxon| taxon.tribe.subfamily }
 
       genus_group_protonym
     end

--- a/spec/models/taxon_sti_subclasses/family_spec.rb
+++ b/spec/models/taxon_sti_subclasses/family_spec.rb
@@ -3,6 +3,16 @@
 require 'rails_helper'
 
 describe Family do
+  describe 'validations' do
+    it { is_expected.to validate_absence_of(:family_id) }
+    it { is_expected.to validate_absence_of(:subfamily_id) }
+    it { is_expected.to validate_absence_of(:tribe_id) }
+    it { is_expected.to validate_absence_of(:genus_id) }
+    it { is_expected.to validate_absence_of(:subgenus_id) }
+    it { is_expected.to validate_absence_of(:species_id) }
+    it { is_expected.to validate_absence_of(:subspecies_id) }
+  end
+
   describe "#parent" do
     let(:family) { create :family }
 

--- a/spec/models/taxon_sti_subclasses/genus_group_taxon_sti_subclasses/genus_spec.rb
+++ b/spec/models/taxon_sti_subclasses/genus_group_taxon_sti_subclasses/genus_spec.rb
@@ -10,6 +10,14 @@ describe Genus do
     it { is_expected.to have_many(:descendants).dependent(:restrict_with_error) }
   end
 
+  describe 'validations' do
+    it { is_expected.to validate_absence_of(:family_id) }
+    it { is_expected.to validate_absence_of(:genus_id) }
+    it { is_expected.to validate_absence_of(:subgenus_id) }
+    it { is_expected.to validate_absence_of(:species_id) }
+    it { is_expected.to validate_absence_of(:subspecies_id) }
+  end
+
   describe "#descendants" do
     let!(:genus) { create :genus }
     let!(:species) { create :species, genus: genus }

--- a/spec/models/taxon_sti_subclasses/genus_group_taxon_sti_subclasses/subgenus_spec.rb
+++ b/spec/models/taxon_sti_subclasses/genus_group_taxon_sti_subclasses/subgenus_spec.rb
@@ -10,6 +10,7 @@ describe Subgenus do
 
   describe 'validations' do
     it { is_expected.to validate_absence_of(:family_id) }
+    it { is_expected.to validate_absence_of(:tribe_id) }
     it { is_expected.to validate_absence_of(:subgenus_id) }
     it { is_expected.to validate_absence_of(:species_id) }
     it { is_expected.to validate_absence_of(:subspecies_id) }

--- a/spec/models/taxon_sti_subclasses/genus_group_taxon_sti_subclasses/subgenus_spec.rb
+++ b/spec/models/taxon_sti_subclasses/genus_group_taxon_sti_subclasses/subgenus_spec.rb
@@ -8,6 +8,13 @@ describe Subgenus do
     it { is_expected.to belong_to(:genus).required }
   end
 
+  describe 'validations' do
+    it { is_expected.to validate_absence_of(:family_id) }
+    it { is_expected.to validate_absence_of(:subgenus_id) }
+    it { is_expected.to validate_absence_of(:species_id) }
+    it { is_expected.to validate_absence_of(:subspecies_id) }
+  end
+
   describe "#update_parent" do
     specify do
       expect { described_class.new.update_parent(nil) }.to raise_error("cannot update parent of subgenera")

--- a/spec/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/infrasubspecies_spec.rb
+++ b/spec/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/infrasubspecies_spec.rb
@@ -16,6 +16,7 @@ describe Infrasubspecies do
   describe 'validations' do
     it { is_expected.to validate_absence_of(:family_id) }
     it { is_expected.to validate_absence_of(:tribe_id) }
+    it { is_expected.to validate_absence_of(:subgenus_id) }
 
     describe '#rank`' do
       subject(:taxon) { create :infrasubspecies }

--- a/spec/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/infrasubspecies_spec.rb
+++ b/spec/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/infrasubspecies_spec.rb
@@ -46,7 +46,6 @@ describe Infrasubspecies do
       expect(infrasubspecies.subspecies).to eq new_parent
       expect(infrasubspecies.species).to eq new_parent.species
       expect(infrasubspecies.genus).to eq new_parent.genus
-      expect(infrasubspecies.subgenus).to eq new_parent.subgenus
       expect(infrasubspecies.subfamily).to eq new_parent.subfamily
     end
 

--- a/spec/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/infrasubspecies_spec.rb
+++ b/spec/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/infrasubspecies_spec.rb
@@ -14,6 +14,9 @@ describe Infrasubspecies do
   end
 
   describe 'validations' do
+    it { is_expected.to validate_absence_of(:family_id) }
+    it { is_expected.to validate_absence_of(:tribe_id) }
+
     describe '#rank`' do
       subject(:taxon) { create :infrasubspecies }
 

--- a/spec/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/species_spec.rb
+++ b/spec/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/species_spec.rb
@@ -14,6 +14,13 @@ describe Species do
     end
   end
 
+  describe 'validations' do
+    it { is_expected.to validate_absence_of(:family_id) }
+    it { is_expected.to validate_absence_of(:tribe_id) }
+    it { is_expected.to validate_absence_of(:species_id) }
+    it { is_expected.to validate_absence_of(:subspecies_id) }
+  end
+
   describe "#children" do
     it "returns the subspecies" do
       species = create :species

--- a/spec/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/subspecies_spec.rb
+++ b/spec/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/subspecies_spec.rb
@@ -14,6 +14,12 @@ describe Subspecies do
     end
   end
 
+  describe 'validations' do
+    it { is_expected.to validate_absence_of(:family_id) }
+    it { is_expected.to validate_absence_of(:tribe_id) }
+    it { is_expected.to validate_absence_of(:subspecies_id) }
+  end
+
   describe "#update_parent" do
     let(:subspecies) { create :subspecies }
     let(:new_parent) { create :species }

--- a/spec/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/subspecies_spec.rb
+++ b/spec/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/subspecies_spec.rb
@@ -30,7 +30,6 @@ describe Subspecies do
 
       expect(subspecies.reload.species).to eq new_parent
       expect(subspecies.reload.genus).to eq new_parent.genus
-      expect(subspecies.reload.subgenus).to eq new_parent.subgenus
       expect(subspecies.reload.subfamily).to eq new_parent.subfamily
     end
 

--- a/spec/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/subspecies_spec.rb
+++ b/spec/models/taxon_sti_subclasses/species_group_taxon_sti_subclasses/subspecies_spec.rb
@@ -17,6 +17,7 @@ describe Subspecies do
   describe 'validations' do
     it { is_expected.to validate_absence_of(:family_id) }
     it { is_expected.to validate_absence_of(:tribe_id) }
+    it { is_expected.to validate_absence_of(:subgenus_id) }
     it { is_expected.to validate_absence_of(:subspecies_id) }
   end
 

--- a/spec/models/taxon_sti_subclasses/subfamily_spec.rb
+++ b/spec/models/taxon_sti_subclasses/subfamily_spec.rb
@@ -10,6 +10,15 @@ describe Subfamily do
     it { is_expected.to have_many(:subspecies).dependent(:restrict_with_error) }
   end
 
+  describe 'validations' do
+    it { is_expected.to validate_absence_of(:subfamily_id) }
+    it { is_expected.to validate_absence_of(:tribe_id) }
+    it { is_expected.to validate_absence_of(:genus_id) }
+    it { is_expected.to validate_absence_of(:subgenus_id) }
+    it { is_expected.to validate_absence_of(:species_id) }
+    it { is_expected.to validate_absence_of(:subspecies_id) }
+  end
+
   describe "#children" do
     it "returns the tribes" do
       subfamily = create :subfamily

--- a/spec/models/taxon_sti_subclasses/subtribe_spec.rb
+++ b/spec/models/taxon_sti_subclasses/subtribe_spec.rb
@@ -4,12 +4,12 @@ require 'rails_helper'
 
 describe Subtribe do
   describe 'relations' do
-    it { is_expected.to belong_to(:subfamily).required }
     it { is_expected.to belong_to(:tribe).required }
   end
 
   describe 'validations' do
     it { is_expected.to validate_absence_of(:family_id) }
+    it { is_expected.to validate_absence_of(:subfamily_id) }
     it { is_expected.to validate_absence_of(:genus_id) }
     it { is_expected.to validate_absence_of(:subgenus_id) }
     it { is_expected.to validate_absence_of(:species_id) }

--- a/spec/models/taxon_sti_subclasses/subtribe_spec.rb
+++ b/spec/models/taxon_sti_subclasses/subtribe_spec.rb
@@ -8,6 +8,14 @@ describe Subtribe do
     it { is_expected.to belong_to(:tribe).required }
   end
 
+  describe 'validations' do
+    it { is_expected.to validate_absence_of(:family_id) }
+    it { is_expected.to validate_absence_of(:genus_id) }
+    it { is_expected.to validate_absence_of(:subgenus_id) }
+    it { is_expected.to validate_absence_of(:species_id) }
+    it { is_expected.to validate_absence_of(:subspecies_id) }
+  end
+
   describe ".valid_subtribe_name?" do
     describe 'invalid names' do
       context 'with non-subtribe ending' do

--- a/spec/models/taxon_sti_subclasses/tribe_spec.rb
+++ b/spec/models/taxon_sti_subclasses/tribe_spec.rb
@@ -10,6 +10,15 @@ describe Tribe do
     it { is_expected.to belong_to(:subfamily).required }
   end
 
+  describe 'validations' do
+    it { is_expected.to validate_absence_of(:family_id) }
+    it { is_expected.to validate_absence_of(:tribe_id) }
+    it { is_expected.to validate_absence_of(:genus_id) }
+    it { is_expected.to validate_absence_of(:subgenus_id) }
+    it { is_expected.to validate_absence_of(:species_id) }
+    it { is_expected.to validate_absence_of(:subspecies_id) }
+  end
+
   describe "#children" do
     it "returns the genera" do
       tribe = create :tribe


### PR DESCRIPTION
For https://github.com/calacademy-research/antcat-issues/issues/125

* Ensure irrelevant columns are not set
* Don't store `subfamily_id` of subtribes (inferrable from tribe)
* Don't store `tribe_id` of subgenera (inferrable from genus)
* Don't store `subgenus_id` of subspecies and infraspecies (inferrable from genus)