### PR TITLE
AntWeb export: update mysql config

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,7 +23,6 @@ services:
 #      - "3306:3306"
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD="true"
-      - MYSQL_USER=root
       - MYSQL_DATABASE=antcat
     networks:
       antcat-network:


### PR DESCRIPTION
```
db_1      | [ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
db_1      |     Remove MYSQL_USER="root" and use one of the following to control the root user password:
db_1      |     - MYSQL_ROOT_PASSWORD
db_1      |     - MYSQL_ALLOW_EMPTY_PASSWORD
db_1      |     - MYSQL_RANDOM_ROOT_PASSWORD
docker_db_1 exited with code 1
```