### PR TITLE
Add missing gem `webrick`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,9 @@ gem 'sassc-rails'
 gem 'sprockets-rails', require: 'sprockets/railtie'
 gem 'uglifier'
 gem 'webpacker', '5.1.1'
+# NOTE: webrick is required for `ReferenceDocument#actual_url`, but specs may incorrectly pass even after removing
+# webrick from here if it happens to be loaded as a dependency for gems in the :test group (for example cucumber-rails).
+gem 'webrick'
 
 gem 'acts_as_list'
 gem 'attr_extras'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -684,6 +684,7 @@ DEPENDENCIES
   unread
   webmock
   webpacker (= 5.1.1)
+  webrick
   will_paginate
 
 RUBY VERSION

--- a/spec/models/reference_document_spec.rb
+++ b/spec/models/reference_document_spec.rb
@@ -63,10 +63,21 @@ describe ReferenceDocument do
   end
 
   describe "#actual_url" do
-    let!(:reference_document) { create :reference_document, :with_reference, :with_deprecated_url }
+    context 'with file (on S3)' do
+      let(:reference_document) { create :reference_document, :with_reference, :with_file }
 
-    it "simply is the `url`" do
-      expect(reference_document.reload.actual_url).to eq reference_document.url
+      it 'links to S3' do
+        expect(reference_document.actual_url).
+          to include "https://s3.amazonaws.com/antcat_test/#{reference_document.id}"
+      end
+    end
+
+    context 'with `url` (no file)' do
+      let(:reference_document) { create :reference_document, :with_reference, :with_deprecated_url }
+
+      it "simply is the `url`" do
+        expect(reference_document.reload.actual_url).to eq reference_document.url
+      end
     end
   end
 end


### PR DESCRIPTION
Missed in #1383

`webrick` is not a default gem in Ruby 3: https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

