### PR TITLE
Use `now_taxon` in antweb exporter

### DIFF
--- a/app/services/exporters/antweb/taxon_attributes.rb
+++ b/app/services/exporters/antweb/taxon_attributes.rb
@@ -56,7 +56,7 @@ module Exporters
         end
 
         def current_valid_name
-          return unless (current_valid_name_name = taxon.current_taxon&.name&.name)
+          return unless (current_valid_name_name = taxon.now_taxon&.name&.name)
           "#{taxonomic_attributes[:subfamily]} #{current_valid_name_name}"
         end
 


### PR DESCRIPTION
The DwC field `acceptedNameUsage` should contain "The full name, with authorship and date information if known, of the currently valid dwc:Taxon". (https://dwc.tdwg.org/terms/#dwc:acceptedNameUsage).

`Taxon.current_taxon` doesn't always refer to the valid name, like for an obsolete combination of a synonym.