### PR TITLE
gems: fix nokogiri platforms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails'
 gem 'ledermann-rails-settings'
 gem 'newrelic_rpm'
+gem 'nokogiri', force_ruby_platform: true
 gem 'paperclip'
 gem 'paper_trail', '~> 16.0'
 # WARNING: Both this and ruby-progressbar define `ProgressBar`; this one is for `rake sunspot:solr:reindex`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -654,6 +654,7 @@ DEPENDENCIES
   ledermann-rails-settings
   mysql2
   newrelic_rpm
+  nokogiri
   paper_trail (~> 16.0)
   paperclip
   progress_bar
@@ -701,4 +702,4 @@ RUBY VERSION
    ruby 3.2.1p31
 
 BUNDLED WITH
-   2.3.10
+   2.6.6


### PR DESCRIPTION
See https://nokogiri.org/tutorials/installing_nokogiri.html#installing-using-the-packaged-libraries

```
+ 1m 29s       ERROR: It looks like you're trying to use Nokogiri as a precompiled native gem on a system
+ 1m 29s              with an unsupported version of glibc.
+ 1m 29s
+ 1m 29s         /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /data/antcat/shared/bundled_gems/ruby/3.2.0/gems/nokogiri-1.18.4-x86_64-linux-gnu/lib/nokogiri/3.2/nokogiri.so) - /data/antcat/shared/bundled_gems/ruby/3.2.0/gems/nokogiri-1.18.4-x86_64-linux-gnu/lib/nokogiri/3.2/nokogiri.so
+ 1m 29s
+ 1m 29s         If that's the case, then please install Nokogiri via the `ruby` platform gem:
+ 1m 29s             gem install nokogiri --platform=ruby
+ 1m 29s         or:
+ 1m 29s             bundle config set force_ruby_platform true
+ 1m 29s
+ 1m 29s         Please visit https://nokogiri.org/tutorials/installing_nokogiri.html for more help.
+ 1m 29s
+ 1m 30s
+ 1m 30s       ERROR: It looks like you're trying to use Nokogiri as a precompiled native gem on a system
+ 1m 30s              with an unsupported version of glibc.
+ 1m 30s
+ 1m 30s         /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /data/antcat/shared/bundled_gems/ruby/3.2.0/gems/nokogiri-1.18.4-x86_64-linux-gnu/lib/nokogiri/3.2/nokogiri.so) - /data/antcat/shared/bundled_gems/ruby/3.2.0/gems/nokogiri-1.18.4-x86_64-linux-gnu/lib/nokogiri/3.2/nokogiri.so
+ 1m 30s
+ 1m 30s         If that's the case, then please install Nokogiri via the `ruby` platform gem:
+ 1m 30s             gem install nokogiri --platform=ruby
+ 1m 30s         or:
+ 1m 30s             bundle config set force_ruby_platform true
+ 1m 30s
+ 1m 30s         Please visit https://nokogiri.org/tutorials/installing_nokogiri.html for more help.
+ 1m 30s
+ 1m 30s       rake aborted!
+ 1m 30s       LoadError: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /data/antcat/shared/bundled_gems/ruby/3.2.0/gems/nokogiri-1.18.4-x86_64-linux-gnu/lib/nokogiri/3.2/nokogiri.so) - /data/antcat/shared/bundled_gems/ruby/3.2.0/gems/nokogiri-1.18.4-x86_64-linux-gnu/lib/nokogiri/3.2/nokogiri.so (LoadError)
```